### PR TITLE
Update en.ui

### DIFF
--- a/en.ui
+++ b/en.ui
@@ -431,7 +431,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="subttile_type">
+           <widget class="QComboBox" name="subtitle_type">
             <property name="minimumSize">
              <size>
               <width>0</width>


### PR DESCRIPTION
Line 434 - the attribute "subtitle_type" with tiping error.

This error is preventing the installation of the Win 11 compiled file. Displaying the following error message:

  File "sp.py", line 321, in <module>
  File "sp.py", line 103, in __init__
  File "sp.py", line 148, in initUI
AttributeError: 'MainWindow' object has no attribute 'subtitle_type'