### PR TITLE
fix: SyntaxError: f-string: unmatched '['

### DIFF
--- a/videotrans/task/trans_create.py
+++ b/videotrans/task/trans_create.py
@@ -411,11 +411,11 @@ class TransCreate():
         if not self.config_params['is_batch']:
             tools.set_process('', 'allow_edit', btnkey=self.init['btnkey'])
         #time.sleep(3)
-        print(f'结束100% {self.obj['raw_basename']}')
+        print(f"结束100% {self.obj['raw_basename']}")
         
         tools.set_process(
             f"{output}##{self.obj['raw_basename']}",
             'succeed',
             btnkey=self.init['btnkey']
         )
-        tools.send_notification("Succeed", f'{self.obj["raw_basename"]}')
+        tools.send_notification("Succeed", f"{self.obj['raw_basename']}")


### PR DESCRIPTION
### Software version:

```bash
➜  pyvideotrans git:(fix/f-string-issue) ✗ python -V
Python 3.9.6
➜  pyvideotrans git:(fix/f-string-issue) ✗ uname -a
Darwin M4MG7YVL9V 22.6.0 Darwin Kernel Version 22.6.0: Tue Nov  7 21:40:08 PST 2023; root:xnu-8796.141.3.702.9~2/RELEASE_ARM64_T6000 arm64
```

### Bug:

``` bash
➜  pyvideotrans git:(main) ✗ python sp.py                  
启动用时：1.6219909191131592
2024-05-08 10:46:35.695 Python[67409:21828346] +[CATransaction synchronize] called within transaction
Traceback (most recent call last):
  File "/Users/x/work/fun_projects/pyvideotrans/videotrans/mainwin/secwin.py", line 1259, in check_start
    from videotrans.task.main_worker import Worker
  File "/Users/x/work/fun_projects/pyvideotrans/videotrans/task/main_worker.py", line 8, in <module>
    from videotrans.task.trans_create import TransCreate
  File "/Users/x/work/fun_projects/pyvideotrans/videotrans/task/trans_create.py", line 414
    print(f'结束100% {self.obj['raw_basename']}')
                                  ^
SyntaxError: f-string: unmatched '['
Traceback (most recent call last):
  File "/Users/x/work/fun_projects/pyvideotrans/videotrans/mainwin/secwin.py", line 1259, in check_start
    from videotrans.task.main_worker import Worker
  File "/Users/x/work/fun_projects/pyvideotrans/videotrans/task/main_worker.py", line 8, in <module>
    from videotrans.task.trans_create import TransCreate
  File "/Users/x/work/fun_projects/pyvideotrans/videotrans/task/trans_create.py", line 414
    print(f'结束100% {self.obj['raw_basename']}')
                                  ^
SyntaxError: f-string: unmatched '['
```