### PR TITLE
Fix bug：第二次及以后进度条卡97%

### DIFF
--- a/videotrans/task/main_worker.py
+++ b/videotrans/task/main_worker.py
@@ -184,10 +184,10 @@ class Worker(QThread):
         if self.is_batch:
             return self.wait_end()
         # 非批量直接结束
-        self.tasklist = {}
         config.queue_mp4 = []
         set_process("", 'end')
         self._unlink_tmp()
+        self.tasklist = {}
         
         
     def _unlink_tmp(self):
@@ -223,15 +223,14 @@ class Worker(QThread):
                 self.unidlist.append(unid)
             time.sleep(0.5)
         # 全部完成
-        self.tasklist = {}
         config.queue_mp4 = []
         set_process("", 'end')
-        
         self._unlink_tmp()
+        self.tasklist = {}
 
     def stop(self):
         set_process("", 'stop')
-        self.tasklist = {}
         config.queue_mp4=[]
         self._unlink_tmp()
+        self.tasklist = {}
 


### PR DESCRIPTION
![image](https://github.com/jianchang512/pyvideotrans/assets/46738432/50019488-7285-41f8-942e-b1451a70ff30)
![image](https://github.com/jianchang512/pyvideotrans/assets/46738432/fe1a6b0a-97c1-4b74-b756-898e73e28e56)
执行到secwin.py 1321行target=self.main.task.tasklist[btnkey].obj['output']时会报KeyError，打印tasklist为空。第一次时不会出现，因为没有走这里。
经过测试分析发现 self.tasklist = {} 置空早了，挪到最后就好了
![image](https://github.com/jianchang512/pyvideotrans/assets/46738432/9ae2e46f-705a-4c55-9ec9-502e985ec252)