### PR TITLE
Quick download of the .exe files from the ffmpeg folder.

### DIFF
--- a/update_ffmpeg.bat
+++ b/update_ffmpeg.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+
+:: Calls the Python script and keeps the window open
+python "%~dp0videotrans\task\update_ffmpeg.py"
+pause
+
+endlocal

--- a/update_ytwin32.bat
+++ b/update_ytwin32.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+
+:: Calls the Python script and keeps the window open
+python "%~dp0videotrans\task\update_ytdlp.py"
+pause
+
+endlocal

--- a/videotrans/task/update_ffmpeg.py
+++ b/videotrans/task/update_ffmpeg.py
@@ -1,0 +1,75 @@
+"""
+# License
+
+This script for downloading/updating ffmpeg was created by Thiago Ramos.
+Contact: thiagojramos@outlook.com
+
+The ffmpeg executables (ffmpeg.exe and ffprobe.exe) are created and maintained by the FFmpeg developers.
+For more information, visit the FFmpeg GitHub repository: https://github.com/BtbN/FFmpeg-Builds
+
+This script is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the authors be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the script or the use or other dealings in the script.
+"""
+
+import os
+import requests
+import zipfile
+import shutil
+
+# Gets the current script's directory
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Defines the destination directory and temporary directory relative to the script directory
+dest_dir = os.path.join(script_dir, "..", "..", "ffmpeg")
+temp_dir = os.path.join(dest_dir, "temp_ffmpeg")
+os.makedirs(dest_dir, exist_ok=True)
+
+# GitHub API URL to get the latest ffmpeg version
+api_url = "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/latest"
+response = requests.get(api_url)
+latest_release = response.json()
+latest_version = latest_release["tag_name"]
+download_url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.0-latest-win64-gpl-7.0.zip"
+
+# Destination path for the download
+zip_path = os.path.join(dest_dir, "ffmpeg.zip")
+
+# Download the zip file
+print("Downloading ffmpeg.zip...")
+with requests.get(download_url, stream=True) as r:
+    r.raise_for_status()
+    with open(zip_path, "wb") as f:
+        for chunk in r.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+# Extract the contents of the zip file
+print("Extracting the contents of ffmpeg.zip...")
+with zipfile.ZipFile(zip_path, "r") as zip_ref:
+    zip_ref.extractall(temp_dir)
+
+# Paths to the binaries within the extracted zip file
+ffmpeg_exe = os.path.join(
+    temp_dir, "ffmpeg-n7.0-latest-win64-gpl-7.0", "bin", "ffmpeg.exe"
+)
+ffprobe_exe = os.path.join(
+    temp_dir, "ffmpeg-n7.0-latest-win64-gpl-7.0", "bin", "ffprobe.exe"
+)
+
+# Checks if the files already exist and removes them if necessary
+if os.path.exists(os.path.join(dest_dir, "ffmpeg.exe")):
+    print("Removing existing ffmpeg.exe file...")
+    os.remove(os.path.join(dest_dir, "ffmpeg.exe"))
+if os.path.exists(os.path.join(dest_dir, "ffprobe.exe")):
+    print("Removing existing ffprobe.exe file...")
+    os.remove(os.path.join(dest_dir, "ffprobe.exe"))
+
+# Moves the new binaries to the destination directory
+print("Moving new binaries to the destination directory...")
+shutil.move(ffmpeg_exe, os.path.join(dest_dir, "ffmpeg.exe"))
+shutil.move(ffprobe_exe, os.path.join(dest_dir, "ffprobe.exe"))
+
+# Clean up temporary files
+print("Cleaning up temporary files...")
+os.remove(zip_path)
+shutil.rmtree(temp_dir)
+
+print("Download, extraction, and replacement completed!")

--- a/videotrans/task/update_ytdlp.py
+++ b/videotrans/task/update_ytdlp.py
@@ -1,0 +1,63 @@
+"""
+# License
+
+This script for downloading/updating yt-dlp was created by Thiago Ramos.
+Contact: thiagojramos@outlook.com
+
+The yt-dlp executable is created and maintained by the yt-dlp developers.
+For more information, visit the yt-dlp GitHub repository: https://github.com/yt-dlp/yt-dlp
+
+This script is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the authors be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the script or the use or other dealings in the script.
+"""
+
+import os
+import requests
+import platform
+
+# Gets the current script's directory
+script_dir = os.path.dirname(os.path.abspath(__file__))
+
+# Defines the destination directory relative to the script directory
+dest_dir = os.path.join(script_dir, "..", "..", "ffmpeg")
+os.makedirs(dest_dir, exist_ok=True)
+
+# Detects the system architecture
+system_architecture = platform.architecture()[0]
+if system_architecture == "64bit":
+    yt_dlp_exe = "yt-dlp.exe"
+    print("Detected system: 64-bit")
+else:
+    yt_dlp_exe = "yt-dlp_x86.exe"
+    print("Detected system: 32-bit")
+
+# GitHub API URL to get the latest yt-dlp version
+api_url = "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest"
+response = requests.get(api_url)
+latest_release = response.json()
+latest_version = latest_release["tag_name"]
+download_url = (
+    f"https://github.com/yt-dlp/yt-dlp/releases/download/{latest_version}/{yt_dlp_exe}"
+)
+
+# Destination path for the download
+output_path = os.path.join(dest_dir, yt_dlp_exe)
+
+# Download the executable
+print(f"Downloading {yt_dlp_exe}...")
+with requests.get(download_url, stream=True) as r:
+    r.raise_for_status()
+    with open(output_path, "wb") as f:
+        for chunk in r.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+# Checks if the file ytwin32.exe already exists and removes it if necessary
+renamed_path = os.path.join(dest_dir, "ytwin32.exe")
+if os.path.exists(renamed_path):
+    print("Removing existing ytwin32.exe file...")
+    os.remove(renamed_path)
+
+# Renames the downloaded file
+print("Renaming the file to ytwin32.exe...")
+os.rename(output_path, renamed_path)
+
+print("Download and renaming completed!")


### PR DESCRIPTION
When you run `git clone` on the repository, you get an error saying, "This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access."

<details><summary>Error message</summary>
<p>

![01](https://github.com/user-attachments/assets/5e7c65be-6bdf-4478-ae53-e3066c26696e)

</p>
</details> 

To work around this, I created two basic scripts that, when executed, download `ytwin32.exe` to the `ffmpeg` folder, as well as the latest versions of `ffmpeg.exe` and `ffprobe.exe`. For `ytwin32.exe`, the script first checks the user's OS architecture (x64 or x86) and downloads the corresponding version.

<details><summary>FFMPEG downloaded</summary>
<p>

![ffmpeg](https://github.com/user-attachments/assets/55153e22-ce8c-4f8a-88f6-a75d4c8ae33a)

</p>
</details> 

<details><summary>ytwin32 downloaded</summary>
<p>

![ytwin32](https://github.com/user-attachments/assets/c3c50ee5-cedb-46d0-9771-ab504f29f66e)

</p>
</details> 


If the user wants to keep them updated or needs to download them again for any reason, they can simply run the scripts again, and they will "update" the files. Oh, and they are downloaded directly from their repositories here on GitHub.

With that done, the .exe file in the remote repository can be deleted to avoid the error message.