### PR TITLE
Avoid converting all values to lowercase upon each configuration load.

### DIFF
--- a/videotrans/configure/config.py
+++ b/videotrans/configure/config.py
@@ -386,7 +386,7 @@ def parse_init():
             elif value.lower() == 'false':
                 _settings[key] = False
             else:
-                _settings[key] = value.lower() if value else ""
+                _settings[key] = value if value else ""
         if _settings['model_list'].find('large-v3-turbo') == -1:
             _settings['model_list']=_settings['model_list'].replace(',large-v3,',',large-v3,large-v3-turbo,')
         if _settings['gemini_model'].find('gemini') == -1:


### PR DESCRIPTION
现在所有设置中的值每次在被加载时都会被转为小写，但很多平台的模型名称都包含大写，目前这些情况下都无法正常使用，如非必要希望去掉此处的大小写转换
![image](https://github.com/user-attachments/assets/e5b70da5-7cb9-4356-98e2-15d34d8a9803)