### PR TITLE
优化了多角色配音的角色选择

### DIFF
--- a/videotrans/mainwin/_actions_sub.py
+++ b/videotrans/mainwin/_actions_sub.py
@@ -744,7 +744,8 @@ class WinActionSub:
                     checked_boxes.extend(get_checked_boxes(child))
             return checked_boxes
 
-        def save(role):
+        def save():
+            role = select_role.currentText()
             # 初始化一个列表，用于存放所有选中 checkbox 的名字
             checked_checkbox_names = get_checked_boxes(box)
             default_role = self.cfg.get('voice_role', 'No')
@@ -803,13 +804,18 @@ class WinActionSub:
 
         select_role = QtWidgets.QComboBox()
         select_role.addItems(self.main.current_rolelist)
-
         select_role.setFixedHeight(35)
-        select_role.currentTextChanged.connect(save)
+
+        apply_role_btn=QtWidgets.QPushButton()
+        apply_role_btn.setMinimumSize(80, 30)
+        apply_role_btn.setText('应用' if config.defaulelang=='zh' else 'Apply')
+        apply_role_btn.clicked.connect(save)
+        
         if self.cfg.get('voice_role', '-') in ['-', 'No','clone']:
             select_role.setDisabled(True)
+            apply_role_btn.setDisabled(True)
         label_role = QtWidgets.QLabel()
-        label_role.setText('单独设置角色' if config.defaulelang == 'zh' else 'Select Role')
+        label_role.setText('设置角色' if config.defaulelang == 'zh' else 'Select Role')
         
         
         source_text=QtWidgets.QLineEdit()
@@ -840,6 +846,7 @@ class WinActionSub:
         self.scroll_area_after = QtWidgets.QHBoxLayout()
         self.scroll_area_after.addWidget(label_role)
         self.scroll_area_after.addWidget(select_role)
+        self.scroll_area_after.addWidget(apply_role_btn)
 
         self.scroll_area = QtWidgets.QScrollArea()
         self.scroll_area.setWidget(box)


### PR DESCRIPTION
使用中发现，如果连续两次操作都设置同一配音角色，需要先切换到其他角色，才能再选原来的角色（因为源码中使用 `QComboBox.currentTextChanged` 触发 `save` 函数来设置，角色没有改变就不会触发），不是很方便。所以在下拉框旁边加入一个“应用”按钮，点击执行 `save` 函数，改变选中字幕的配音角色。


PS: 现学的 PyQt，如有错误请见谅