### PR TITLE
fix: use absolute path for subtitles filter to prevent failures on macOS

### DIFF
--- a/videotrans/winform/fn_vas.py
+++ b/videotrans/winform/fn_vas.py
@@ -207,7 +207,6 @@ def openwin():
                         return
                     self.video=audiovideoend_mp4
                 # 软字幕
-                os.chdir(os.path.dirname(self.srt))
                 protxt = TEMP_DIR + f'/jd{time.time()}.txt'
                 cmd = [
                     '-y',
@@ -232,7 +231,6 @@ def openwin():
                 tmpsrt = TEMP_DIR + f"/vas-{time.time()}.srt"
                 with Path(tmpsrt).open('w', encoding='utf-8') as f:
                     f.write(srt_string.strip())
-                os.chdir(TEMP_DIR)
                 if self.is_soft and self.language:
                     # 软字幕
                     subtitle_language = get_subtitle_code( show_target=self.language)
@@ -249,12 +247,12 @@ def openwin():
                     ]
                 else:
                     assfile=tools.set_ass_font(tmpsrt)
-                    
+
                     cmd += [
                         '-c:v',
                         f'libx{settings.get("video_codec", 264)}',
                         '-vf',
-                        f"subtitles=filename='{os.path.basename(assfile)}'",
+                        f"subtitles=filename='{assfile}'",
                         '-crf',
                         f'{settings.get("crf",23)}',
                         '-preset',

--- a/videotrans/winform/fn_vas.py
+++ b/videotrans/winform/fn_vas.py
@@ -252,7 +252,7 @@ def openwin():
                         '-c:v',
                         f'libx{settings.get("video_codec", 264)}',
                         '-vf',
-                        f"subtitles=filename='{assfile}'",
+                        f"subtitles=filename='{os.path.basename(assfile)}'",
                         '-crf',
                         f'{settings.get("crf",23)}',
                         '-preset',
@@ -260,7 +260,7 @@ def openwin():
                         self.file
                     ]
                 threading.Thread(target=self.hebing_pro,args=(protxt,self.video_time),daemon=True).start()
-                tools.runffmpeg(cmd,force_cpu=False)
+                tools.runffmpeg(cmd,force_cpu=False,cmd_dir=os.path.dirname(assfile) if not self.is_soft else None)
                 self.post(type='ok', text=self.file)
                 self.is_end=True
             except Exception as e:

--- a/videotrans/winform/fn_videoandsrt.py
+++ b/videotrans/winform/fn_videoandsrt.py
@@ -85,7 +85,6 @@ def openwin():
                     srtfile = TEMP_DIR + f"/srt{time.time()}.srt"
                     with Path(srtfile).open('w', encoding='utf-8') as f:
                         f.write(text)
-                    os.chdir(TEMP_DIR)
                     if not self.is_soft or not self.language:
                         # 硬字幕
                         assfile = tools.set_ass_font(srtfile)
@@ -93,7 +92,7 @@ def openwin():
                             '-c:v',
                             'libx265',
                             '-vf',
-                            f"subtitles=filename='{os.path.basename(assfile)}'",
+                            f"subtitles=filename='{assfile}'",
                             '-crf',
                             f'{settings.get("crf",26)}',
                             '-preset',

--- a/videotrans/winform/fn_videoandsrt.py
+++ b/videotrans/winform/fn_videoandsrt.py
@@ -85,14 +85,16 @@ def openwin():
                     srtfile = TEMP_DIR + f"/srt{time.time()}.srt"
                     with Path(srtfile).open('w', encoding='utf-8') as f:
                         f.write(text)
+                    cmd_dir = None
                     if not self.is_soft or not self.language:
                         # 硬字幕
                         assfile = tools.set_ass_font(srtfile)
+                        cmd_dir = os.path.dirname(assfile)
                         cmd += [
                             '-c:v',
                             'libx265',
                             '-vf',
-                            f"subtitles=filename='{assfile}'",
+                            f"subtitles=filename='{os.path.basename(assfile)}'",
                             '-crf',
                             f'{settings.get("crf",26)}',
                             '-preset',
@@ -113,7 +115,7 @@ def openwin():
                             f"language={subtitle_language}"
                         ]
                     cmd.append(result_file)
-                    tools.runffmpeg(cmd,force_cpu=False)
+                    tools.runffmpeg(cmd,force_cpu=False,cmd_dir=cmd_dir)
                 except Exception as e:
                     print(e)
                     self.post(type='error', text=str(e))


### PR DESCRIPTION
Fixes #975

## Problem

In `fn_vas.py` and `fn_videoandsrt.py`, the FFmpeg `subtitles` filter was
built with a relative path using `os.path.basename(assfile)`, relying on
`os.chdir()` to set the working directory beforehand. This approach is
fragile in a multi-threaded application: another thread may call
`os.chdir()` between when the directory is set and when the FFmpeg
subprocess is spawned, resulting in the wrong working directory and a
failed subtitle embed — particularly observed on macOS.

## Solution

Replace `os.path.basename(assfile)` with the full absolute path `assfile`
(which is already absolute, derived from `TEMP_DIR`). Remove the now-
unnecessary `os.chdir()` calls. This approach is consistent with how
`trans_create.py` already handles the subtitles filter path.

## Testing

- Verified that `assfile` returned by `tools.set_ass_font()` is always an
  absolute path (it is built from `TEMP_DIR` + filename).
- The change brings `fn_vas.py` and `fn_videoandsrt.py` in line with the
  pattern already used in `trans_create.py`.