### PR TITLE
fix: preserve SRT structure when 'Preserve line breaks' is enabled in Batch Video Srt merger

### DIFF
--- a/videotrans/winform/fn_videoandsrt.py
+++ b/videotrans/winform/fn_videoandsrt.py
@@ -78,7 +78,7 @@ def openwin():
                             txt_list = []
                             for txt_line in it['text'].strip().split("\n"):
                                 txt_list.append(tools.textwrap(txt_line.strip(), self.maxlen))
-                            text+= "\n".join(txt_list)
+                            text += f"{it['line']}\n{it['time']}\n{chr(10).join(txt_list)}\n\n"
                         else:
                             it['text'] = tools.textwrap(it['text'], self.maxlen).strip()
                             text += f"{it['line']}\n{it['time']}\n{it['text'].strip()}\n\n"


### PR DESCRIPTION
Fixes #968

## Problem

In the **Batch Video Srt merger** (`fn_videoandsrt.py`), when the **\"Preserve line breaks\"** (`remain_hr`) checkbox is enabled, the subtitle text was appended to the output buffer without the required SRT structure (line number, timestamp prefix, and trailing blank line):

```python
# Before fix — missing SRT structure
text += "\n".join(txt_list)
```

This produced a malformed SRT file that could not be correctly parsed by `set_ass_font`, causing subtitles to either fail to embed or display with broken/missing line breaks.

## Solution

Mirror the correct implementation already used in `fn_vas.py` (the single-file Video Subtitles Merging tool), which wraps each subtitle entry with its index and timestamp:

```python
# After fix — correct SRT structure preserved
text += f"{it['line']}\n{it['time']}\n{chr(10).join(txt_list)}\n\n"
```

The non-`remain_hr` branch was already correct; only the `remain_hr=True` path needed updating.

## Testing

- Verified the fix by comparing the generated SRT output structure when `remain_hr=True` against the working `fn_vas.py` implementation.
- The `else` branch is unchanged.