### PR TITLE
Fix: FunASR crashes on macOS due to unsupported MPS device

### DIFF
--- a/videotrans/process/stt_fun.py
+++ b/videotrans/process/stt_fun.py
@@ -663,7 +663,8 @@ def paraformer(
 
     raw_subtitles = []
     model = None
-    device = f'cuda:{device_index}' if is_cuda else gpus.mps_or_cpu()
+    # ModelScope pipeline only accepts cpu/cuda/gpu, not mps
+    device = f'cuda:{device_index}' if is_cuda else 'cpu'
     try:
         model = pipeline(
             task=Tasks.auto_speech_recognition,
@@ -897,7 +898,8 @@ def funasr_mlt(
     _write_log(logs_file, json.dumps({"type": "logs", "text": f'{msg}'}))
 
     model = None
-    device = f"cuda:{device_index}" if is_cuda else gpus.mps_or_cpu()
+    # ModelScope pipeline only accepts cpu/cuda/gpu, not mps
+    device = f"cuda:{device_index}" if is_cuda else 'cpu'
     try:
         if cut_audio_list and isinstance(cut_audio_list, str):
             cut_audio_list = json.loads(Path(cut_audio_list).read_text(encoding='utf-8'))


### PR DESCRIPTION
## Summary

- `paraformer()` and `funasr_mlt()` in `videotrans/process/stt_fun.py` use `gpus.mps_or_cpu()` which returns `"mps"` on Apple Silicon macOS
- ModelScope's `pipeline()` only accepts `"cpu"` / `"cuda"` / `"gpu"` as device arguments — `"mps"` causes `AssertionError`
- Changed both functions to use `"cpu"` when `is_cuda=False`, since ModelScope does not support MPS acceleration

## Bug Reproduction

On macOS with Apple Silicon:
```bash
python cli.py --task stt --name video.mp4 --detect_language zh --source_language_code zh --recogn_type 3 --model_name paraformer-zh
```

Error:
```
AssertionError: FunASRPipeline: device should be either cpu, cuda, gpu, gpu:X or cuda:X where X is the ordinal for gpu device.
```

## Test Plan

- [x] Verified fix on macOS M2 Max: FunASR paraformer-zh runs successfully (23s for 28s video)
- [x] Verified faster-whisper (recogn_type=0) unaffected — uses different code path (transformers pipeline, not ModelScope)
- [x] Verified `stt_fun.py:531` unchanged — that line uses HuggingFace transformers which does support MPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)