### PR TITLE
Fix: ElevenLabs voice role shows duplicates for v2/v3 same name

### DIFF
--- a/videotrans/util/help_role.py
+++ b/videotrans/util/help_role.py
@@ -168,12 +168,11 @@ def get_elevenlabs_role(force=False, raise_exception=False):
         client = ElevenLabs(api_key=params.get("elevenlabstts_key",''))
         voiceslist = client.voices.get_all()
 
-        namelist=['No']
         result = {}
         for it in voiceslist.voices:
             n = re.sub(r'[^a-zA-Z0-9_ -]+', '', it.name,flags=re.I | re.S).strip()
             result[n] = {"name": n, "voice_id": it.voice_id}
-            namelist.append(n)
+        namelist = ['No'] + list(result.keys())
 
         with open(jsonfile, 'w', encoding="utf-8") as f:
             f.write(json.dumps(result))


### PR DESCRIPTION
## Summary
- Deduplicate voice names in ElevenLabs role dropdown by building `namelist` from `result.keys()` after the loop instead of appending per iteration

## Problem
When ElevenLabs returns both v2 and v3 versions of a voice with the same name, the voice appeared twice in the role dropdown. The `result` dict already correctly keeps the last (v3) `voice_id`, but `namelist` was appending on every iteration causing duplicates.

## Fix
Build `namelist` from deduplicated `result.keys()` after the loop completes, ensuring each voice name appears only once.

Closes #983

🤖 Generated with [Claude Code](https://claude.com/claude-code)