### PR TITLE
Fix voice role dropdown empty for Google TTS at startup

### DIFF
--- a/videotrans/mainwin/_main_win.py
+++ b/videotrans/mainwin/_main_win.py
@@ -460,6 +460,11 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         elif tts_type == tts.GEMINI_TTS:
             rolelist = params.get('gemini_ttsrole', '')
             self.voice_role.addItems(['No'] + rolelist.split(','))
+        elif tts_type == tts.GOOGLE_TTS:
+            self.voice_role.addItems(['No', 'gtts'])
+        elif tts_type == tts.Supertonic_TTS:
+            rolelist = list(tools.get_supertonic_rolelist().keys())
+            self.voice_role.addItems(rolelist)
         elif self.win_action.change_by_lang(tts_type):
             self.voice_role.clear()
 


### PR DESCRIPTION
## Summary
- `_set_default()` in `_main_win.py` calls `tts_type_change()` to populate the voice_role dropdown, then immediately calls `voice_role.clear()` and rebuilds from a separate `elif` chain
- Google TTS and Supertonic TTS were missing from that `elif` chain, leaving the dropdown empty at startup
- Adding both cases so the voice role is correctly populated on app launch

## Root cause
`_set_default()` line 419 calls `tts_type_change()` which correctly sets `['No', 'gtts']` for Google TTS. Then line 426 calls `voice_role.clear()`, and the subsequent elif chain (lines 427-464) had no case for `GOOGLE_TTS` or `Supertonic_TTS`, so the dropdown stayed empty.

## Test plan
- [ ] Set Google TTS as the saved TTS type, restart app → voice role dropdown shows `['No', 'gtts']`
- [ ] Set Supertonic TTS as the saved TTS type, restart app → voice role dropdown shows Supertonic voices
- [ ] Switch to Google TTS at runtime → voice role dropdown still works (no regression)

Closes #978

🤖 Generated with [Claude Code](https://claude.com/claude-code)