### PR TITLE
Fix subtitle timestamp alignment when translation returns extra lines

### DIFF
--- a/videotrans/component/onlyone_set_role.py
+++ b/videotrans/component/onlyone_set_role.py
@@ -41,7 +41,8 @@ class SpeakerAssignmentDialog(QDialog):
             if sour_pt.as_posix() and not sour_pt.samefile(Path(target_sub)):
                 try:
                     self.source_srtstring = sour_pt.read_text(encoding="utf-8")
-                except:
+                except Exception:
+                    logger.exception(f'Failed to read source subtitle: {source_sub}', exc_info=True)
                     self.source_srtstring = ""
 
         self.srt_list_dict = tools.get_subtitle_from_srt(self.target_sub)

--- a/videotrans/task/_base.py
+++ b/videotrans/task/_base.py
@@ -128,6 +128,10 @@ class BaseTask(BaseCon):
 
         if target_len>source_len:
             logger.debug(f'翻译结果行数大于原始字幕行，截取0-{source_len}')
+            for i,it in enumerate(source_srt_list):
+                tmp = copy.deepcopy(it)
+                tmp['text'] = target_srt_list[i]['text']
+                target_srt_list[i] = tmp
             return target_srt_list[:source_len]
         
         

--- a/videotrans/task/_speech2text.py
+++ b/videotrans/task/_speech2text.py
@@ -221,8 +221,8 @@ class SpeechToText(BaseTask):
                             if self.cfg.detect_language[:2]=='en':
                                 it['text']=it['text'].replace('，',',').replace('。','. ').replace('？','?').replace('！','!')
                         self._save_srt_target(self.source_srt_list, self.cfg.target_sub)
-                except:
-                    pass
+                except Exception:
+                    logger.exception('Punctuation restoration failed', exc_info=True)
 
             
             # whisperx-api


### PR DESCRIPTION
## Summary
- **Bug fix in `_base.py`**: When translation API returns more subtitle lines than the source, `_check_target_sub()` truncated the target but kept the translation API's timestamps instead of copying the correct source timestamps. This caused subtitle timing mismatches.
- **Improved error logging**: Replaced two bare `except:` blocks that silently swallowed errors:
  - `_speech2text.py`: Punctuation restoration failure now logs instead of silently passing
  - `onlyone_set_role.py`: Source subtitle read failure now logs

## Root cause (_base.py)
The `_check_target_sub()` method handles 3 cases:
1. `source_len == target_len`: ✅ Correctly copies source timestamps
2. `target_len > source_len`: ❌ **Truncated target but kept wrong timestamps** → now fixed
3. `target_len < source_len`: ✅ Correctly copies source timestamps for appended entries

## Test plan
- [ ] Translate a video where the translation API returns more lines than the source → timestamps should match the source, not the translation API
- [ ] Trigger a punctuation restoration failure → should see log entry instead of silent failure
- [ ] Open "Edit subs & assign roles" with an unreadable source subtitle → should see log entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)