### PR TITLE
Fix SRT parsing failure for files with UTF-8 BOM

### DIFF
--- a/videotrans/util/help_srt.py
+++ b/videotrans/util/help_srt.py
@@ -209,7 +209,7 @@ def get_subtitle_from_srt(srtfile, *, is_file=True):
     def _readfile(file):
         content = ""
         try:
-            with open(file, 'r', encoding='utf-8') as f:
+            with open(file, 'r', encoding='utf-8-sig') as f:
                 content = f.read().strip()
         except UnicodeDecodeError as e:
             try:


### PR DESCRIPTION
## Summary
- `get_subtitle_from_srt()` opens SRT files with `encoding='utf-8'`, which includes the BOM character in the content
- This causes the SRT parser to fail because the first line starts with an invisible BOM character instead of a valid subtitle index number
- Changed to `encoding='utf-8-sig'` which transparently strips the BOM

## Impact
SRT files exported from Windows tools (Notepad, Subtitle Edit, etc.) often have a UTF-8 BOM. Users would get cryptic parsing errors when trying to use these files.

## Test plan
- [ ] Load an SRT file with UTF-8 BOM → should parse correctly
- [ ] Load an SRT file without BOM → should still work (utf-8-sig is backward compatible)
- [ ] Load an SRT file with GBK encoding → should still fall back to GBK decoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)