### PR TITLE
Fix: os.chdir not restored on subtitle embedding error

### DIFF
--- a/videotrans/task/trans_create.py
+++ b/videotrans/task/trans_create.py
@@ -1543,8 +1543,8 @@ class TransCreate(BaseTask):
         except Exception as e:
             msg = tr('Error in embedding the final step of the subtitle dubbing')
             raise RuntimeError(msg)
-
-        os.chdir(ROOT_DIR)
+        finally:
+            os.chdir(ROOT_DIR)
         if Path(tmp_target_mp4).exists():
             try:
                 shutil.copy2(tmp_target_mp4, self.cfg.targetdir_mp4)


### PR DESCRIPTION
## Summary
- `os.chdir(ROOT_DIR)` in `trans_create.py:1547` was placed after the `try/except` block
- When the subtitle embedding step failed, `raise RuntimeError()` at line 1545 skipped the `os.chdir(ROOT_DIR)` restore
- This left the process working directory stuck in the cache folder, causing subsequent file operations to fail or target wrong paths

## Fix
Move `os.chdir(ROOT_DIR)` into a `finally:` block so it always executes regardless of success or failure.

## Test plan
- [ ] Run a video translation task that fails during the subtitle embedding step
- [ ] Verify the working directory is restored to ROOT_DIR after the error
- [ ] Verify normal video translation still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)