### PR TITLE
Fix: speech recognition infinite loop when audio preparation fails

### DIFF
--- a/videotrans/task/_speech2text.py
+++ b/videotrans/task/_speech2text.py
@@ -56,6 +56,8 @@ class SpeechToText(BaseTask):
     def recogn(self):
         if self._exit(): return
         while 1:
+            if self._exit():
+                return
             # 尚未生成
             if Path(self.cfg.shibie_audio).exists():
                 break


### PR DESCRIPTION
## Summary
- `SpeechToText.recogn()` in `_speech2text.py` has a `while 1:` loop waiting for the audio file to appear
- The loop never checked `_exit()` — if `prepare()` failed to create the audio file, or the user clicked "stop", the loop spun forever
- This is likely the root cause of issue #1023 where the app freezes after showing "语音识别转文字处理中"

## Fix
Added `self._exit()` check inside the `while 1:` loop, matching the pattern used by all other worker threads in `job.py`.

## Test plan
- [ ] Start speech recognition on a video, then click stop — verify it stops promptly
- [ ] Force `prepare()` to fail (e.g., invalid video file) — verify `recogn()` exits instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)