### PR TITLE
Fix: NameError in secondary recognition when audio conversion succeeds

### DIFF
--- a/videotrans/task/trans_create.py
+++ b/videotrans/task/trans_create.py
@@ -498,10 +498,9 @@ class TransCreate(BaseTask):
         except Exception as e:
             logger.exception(f'二次识别配音音频生成字幕时，预处理音频失败，静默跳过:{e}', exc_info=True)
             return
-        finally:
-            if not tools.vail_file(shibie_audio):
-                logger.exception(f'二次识别配音音频生成字幕时，预处理音频失败，静默跳过:{e}', exc_info=True)
-                return
+        if not tools.vail_file(shibie_audio):
+            logger.error(f'二次识别配音音频生成字幕时，预处理音频失败，文件无效，静默跳过')
+            return
         
         try:
             # 判断原渠道是否支持目标语言的识别 self.cfg.target_language_code


### PR DESCRIPTION
## Summary
- In `trans_create.py`, the `try/except/finally` pattern for secondary recognition had a bug
- The `finally` block referenced variable `e` from the `except` clause
- When `conver_to_16k` succeeded but the output file was invalid, `e` was undefined, causing `NameError`
- The `return` inside `finally` is also a Python anti-pattern that can silently swallow exceptions

## Fix
Replaced the confusing `try/except/finally:return` pattern with straightforward `try/except` + post-check:
```python
try:
    tools.conver_to_16k(...)
except Exception as e:
    logger.exception(...)
    return
if not tools.vail_file(shibie_audio):
    logger.error(...)
    return
```

## Test plan
- [ ] Run a video translation where `conver_to_16k` succeeds normally — verify continuation
- [ ] Run with an audio file that causes `conver_to_16k` to fail — verify graceful skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)