### PR TITLE
Fix: CLI vtv mode skips speaker diarization and secondary recognition

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -277,9 +277,11 @@ def main():
         trk = TransCreate(cfg=TaskCfgVTT(**params))
         trk.prepare()
         trk.recogn()
+        trk.diariz()
         trk.trans()
         trk.dubbing()
         trk.align()
+        trk.recogn2pass()
         trk.assembling()
         trk.task_done()
 


### PR DESCRIPTION
## Summary
- The CLI `vtv` (video-to-video) task in `cli.py` was missing two steps that the GUI equivalent (`_only_one.py`) performs:
  1. `trk.diariz()` — speaker diarization is silently skipped in CLI mode even when enabled
  2. `trk.recogn2pass()` — secondary recognition of dubbing audio is not performed

## Comparison

**GUI flow** (`_only_one.py`):
```
prepare → recogn → diariz → trans → dubbing → align → recogn2pass → assembling → task_done
```

**CLI flow** (before this fix):
```
prepare → recogn → trans → dubbing → align → assembling → task_done
```

## Test plan
- [ ] Run `python cli.py vtv` with speaker diarization enabled — verify speakers are identified
- [ ] Run `python cli.py vtv` with dubbing enabled — verify secondary recognition runs after alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)