### PR TITLE
Fix: unhandled ValueError when ffprobe returns empty duration

### DIFF
--- a/videotrans/util/help_ffmpeg.py
+++ b/videotrans/util/help_ffmpeg.py
@@ -432,7 +432,10 @@ def _get_ms_from_media(file):
         # mkv 等其他格式可能无法从流中读取 duration
         pass
     if ms==0:
-        ms=int(float(runffprobe(['-v','error','-show_entries','format=duration','-of','default=noprint_wrappers=1:nokey=1',file])))
+        try:
+            ms=int(float(runffprobe(['-v','error','-show_entries','format=duration','-of','default=noprint_wrappers=1:nokey=1',file])))
+        except (ValueError, TypeError):
+            ms = 0
     return ms
 
 


### PR DESCRIPTION
## Summary
- `_get_ms_from_media()` in `help_ffmpeg.py` has a two-step duration lookup
- Step 1 (stream duration) is wrapped in `try/except` 
- Step 2 (format duration fallback) was NOT — if ffprobe returns empty/invalid output for a corrupted file, `float("")` crashes with `ValueError`
- This function is called by `get_video_duration()`, `get_audio_time()`, and `get_video_ms_noaudio()` — all critical timing functions

## Fix
Wrap the fallback `float()` call in `try/except (ValueError, TypeError)`.

## Test plan
- [ ] Process a corrupted/truncated video file — verify graceful failure instead of crash
- [ ] Process a normal video — verify duration is still correctly detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)