### PR TITLE
Fix: resource leaks and IndexError in subtitle wrapping

### DIFF
--- a/videotrans/recognition/_google.py
+++ b/videotrans/recognition/_google.py
@@ -37,7 +37,8 @@ class GoogleRecogn(BaseRecogn):
         normalized_sound = AudioSegment.from_wav(self.audio_file)  # -20.0
         nonslient_file = f'{tmp_path}/detected_voice.json'
         if tools.vail_file(nonslient_file):
-            nonsilent_data = json.load(open(nonslient_file, 'r'))
+            with open(nonslient_file, 'r') as f:
+                nonsilent_data = json.load(f)
         else:
             nonsilent_data = self._shorten_voice_old(normalized_sound)
             with open(nonslient_file, 'w') as f:

--- a/videotrans/tts/_geminitts.py
+++ b/videotrans/tts/_geminitts.py
@@ -127,9 +127,8 @@ class GEMINITTS(BaseTTS):
             return {"bits_per_sample": bits_per_sample, "rate": rate}
 
         def save_binary_file(file_name, data):
-            f = open(file_name, "wb")
-            f.write(data)
-            f.close()
+            with open(file_name, "wb") as f:
+                f.write(data)
 
         client = genai.Client(
             api_key=params.get('gemini_key', ''),

--- a/videotrans/util/help_srt.py
+++ b/videotrans/util/help_srt.py
@@ -508,6 +508,8 @@ def simple_wrap(text,maxlen=15,language="en"):
         # 再判断后续4个是否符合换行条件
         raw_i=i
         for next_i in range(1,offset+1):
+            if i+next_i>=_len:
+                break
             if text[i+next_i] in flag:
                 pos_i=i+next_i+1
                 current_text+=text[i:pos_i]
@@ -528,7 +530,7 @@ def simple_wrap(text,maxlen=15,language="en"):
             current_text=''
         i+=1
 
-    if current_text and len(current_text)<maxlen/3:
+    if current_text and len(current_text)<maxlen/3 and text_lilst:
         text_lilst[-1]+=current_text
     elif current_text:
         text_lilst.append(current_text)


### PR DESCRIPTION
## Summary
- **`_geminitts.py`**: Replace manual `open()/close()` with `with` statement to prevent file handle leak on exception
- **`_google.py`**: Use `with` statement for `json.load(open(...))` to prevent file handle leak
- **`help_srt.py`**: Add bounds check in `simple_wrap()` to prevent `IndexError` when looking ahead for punctuation near end of string; guard `text_lilst[-1]` access when list is empty

## Test plan
- [x] Tested `simple_wrap()` with various edge cases (short text, small maxlen, CJK, punctuation)
- [x] Verified `_geminitts.py` change is functionally identical (write + close → with block)
- [x] Verified `_google.py` change is functionally identical (open for read → with block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)