### PR TITLE
Fix: preserve vocal.wav when instrument.wav is missing in clone mode

### DIFF
--- a/videotrans/task/trans_create.py
+++ b/videotrans/task/trans_create.py
@@ -239,11 +239,15 @@ class TransCreate(BaseTask):
                 except Exception as e:
                     logger.exception(f'分离人声背景声失败', exc_info=True)
                 finally:
-                    if not tools.vail_file(self.cfg.vocal) or not tools.vail_file(self.cfg.instrument):
+                    if not tools.vail_file(self.cfg.vocal) and not tools.vail_file(self.cfg.instrument):
                         # 分离失败
                         self.cfg.instrument = None
                         self.cfg.vocal = None
                         self.cfg.is_separate = False
+                        self.shoud_separate = False
+                    elif not tools.vail_file(self.cfg.instrument):
+                        # vocal 存在但 instrument 不存在，跳过背景音混合
+                        self.cfg.instrument = None
                         self.shoud_separate = False
             
         


### PR DESCRIPTION
## Summary

When a user manually places `vocal.wav` in the target directory (e.g., pre-separated with another tool) for clone mode but doesn't have `instrument.wav`, the separation fallback logic would set **both** `vocal` and `instrument` to `None`, discarding the user's valid vocal file.

The `finally` block after vocal/instrument separation used `or` logic: if **either** file was invalid, both were reset. This meant a user-provided vocal.wav was always thrown away when instrument.wav was missing.

**Fix:** Change the condition from `or` to `and` — only fully reset when **both** files are invalid. When only instrument is missing, keep the valid vocal for speech recognition and set `shoud_separate=False` to skip background music mixing.

## Before
```python
if not tools.vail_file(self.cfg.vocal) or not tools.vail_file(self.cfg.instrument):
    # Both reset to None — even if vocal was valid
```

## After
```python
if not tools.vail_file(self.cfg.vocal) and not tools.vail_file(self.cfg.instrument):
    # Both missing → full reset
elif not tools.vail_file(self.cfg.instrument):
    # Only instrument missing → keep vocal, skip bgm mixing
```

Partially addresses #1013 (vocal.wav handling in clone mode)

## Test plan
- [x] Verified `_separate()` already checks `not tools.vail_file(self.cfg.instrument)` before attempting bgm mixing
- [x] Verified downstream code at line 1164 handles missing instrument gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)