### PR TITLE
Fix: subprocess log monitor loop ignores app exit signal

### DIFF
--- a/videotrans/configure/_base.py
+++ b/videotrans/configure/_base.py
@@ -218,6 +218,8 @@ class BaseCon:
     def _signal_of_process(self, logs_file):
         last_mtime = 0
         while 1:
+            if app_cfg.exit_soft:
+                return
             _p = Path(logs_file)
             # 已删掉
             if last_mtime>0 and not _p.exists():


### PR DESCRIPTION
## Summary

The `_signal_of_process()` while loop in `_base.py` monitors subprocess log files to relay progress signals, but had no `exit_soft` check. If a subprocess hangs indefinitely (e.g., GPU OOM, model download stuck), this daemon thread would keep spinning and consuming CPU even after the user requests app shutdown.

Add `app_cfg.exit_soft` check at the top of the loop iteration to allow clean termination.

Same pattern as PR #1038 which fixed the `_speech2text.py` `while 1` loop.

## Test plan
- [x] Verified this follows the same pattern used in `job.py` worker threads and PR #1038's fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)