### PR TITLE
Fix: format duration fallback returns seconds not milliseconds

### DIFF
--- a/videotrans/util/help_ffmpeg.py
+++ b/videotrans/util/help_ffmpeg.py
@@ -432,7 +432,10 @@ def _get_ms_from_media(file):
         # mkv 等其他格式可能无法从流中读取 duration
         pass
     if ms==0:
-        ms=int(float(runffprobe(['-v','error','-show_entries','format=duration','-of','default=noprint_wrappers=1:nokey=1',file])))
+        try:
+            ms=int(float(runffprobe(['-v','error','-show_entries','format=duration','-of','default=noprint_wrappers=1:nokey=1',file]))*1000)
+        except (ValueError, TypeError):
+            ms = 0
     return ms
 
 


### PR DESCRIPTION
## Summary

**Critical timing bug**: In `_get_ms_from_media()`, when stream-specific duration probing fails (e.g., certain MKV/container formats) and the code falls back to format-level duration via ffprobe, the result was **not multiplied by 1000** to convert seconds to milliseconds.

The stream-duration path (lines 428, 430) correctly does `int(float(...) * 1000)`, but the format-duration fallback (line 435) was just `int(float(...))`.

**Impact**: A 30-second video would report its duration as 30ms instead of 30000ms. This breaks all downstream timing calculations including subtitle synchronization, video assembly, and audio alignment. Only affects files where stream-level duration is unavailable.

## Before
```python
ms=int(float(runffprobe([...format=duration...])))  # returns seconds, e.g., 30
```

## After
```python
ms=int(float(runffprobe([...format=duration...]))*1000)  # returns ms, e.g., 30000
```

Also includes the ValueError/TypeError exception handling from PR #1041.

## Test plan
- [x] Verified both stream-duration paths (lines 428, 430) already multiply by 1000
- [x] Verified `get_video_info()` format-duration path (line 368, 370) already multiplies by 1000
- [x] This was the only path missing the conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)