### PR TITLE
Fix: uvr_models None 导致 AttributeError

### DIFF
--- a/videotrans/task/separate_worker.py
+++ b/videotrans/task/separate_worker.py
@@ -39,7 +39,7 @@ class SeparateWorker(QThread):
     def run(self):
         try:
             
-            uvr_models=settings.get('uvr_models')
+            uvr_models=settings.get('uvr_models') or 'spleeter'
             if uvr_models.startswith('spleeter'):
                 tools.down_file_from_ms(f'{ROOT_DIR}/models/onnx', [
                     f"https://www.modelscope.cn/models/himyworld/videotrans/resolve/master/onnx/vocals.fp16.onnx",

--- a/videotrans/task/trans_create.py
+++ b/videotrans/task/trans_create.py
@@ -963,7 +963,7 @@ class TransCreate(BaseTask):
         if tools.vail_file(self.cfg.vocal) and tools.vail_file(self.cfg.instrument):
             return
         title = tr('Separating vocals and background music, which may take a longer time')
-        uvr_models=settings.get('uvr_models')
+        uvr_models=settings.get('uvr_models') or 'spleeter'
         if uvr_models.startswith('spleeter'):
             tools.down_file_from_ms(f'{ROOT_DIR}/models/onnx', [
                 f"https://www.modelscope.cn/models/himyworld/videotrans/resolve/master/onnx/vocals.fp16.onnx",


### PR DESCRIPTION
## Summary
- `settings.get('uvr_models')` 在配置项缺失时返回 `None`，导致 `uvr_models.startswith('spleeter')` 抛出 `AttributeError`
- 在 `trans_create.py:966` 和 `separate_worker.py:42` 两处添加 `or 'spleeter'` 默认值守卫

## Test plan
- [ ] 确认 `settings` 中无 `uvr_models` 键时不再崩溃
- [ ] 确认正常配置值不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)