### PR TITLE
Fix: hebing 阶段 os.chdir 异常时未恢复 + while 等待缺少退出检查

### DIFF
--- a/videotrans/task/trans_create.py
+++ b/videotrans/task/trans_create.py
@@ -1543,8 +1543,9 @@ class TransCreate(BaseTask):
         except Exception as e:
             msg = tr('Error in embedding the final step of the subtitle dubbing')
             raise RuntimeError(msg)
+        finally:
+            os.chdir(ROOT_DIR)
 
-        os.chdir(ROOT_DIR)
         if Path(tmp_target_mp4).exists():
             try:
                 shutil.copy2(tmp_target_mp4, self.cfg.targetdir_mp4)
@@ -1555,7 +1556,7 @@ class TransCreate(BaseTask):
         time.sleep(1)
         # 有可能输出原始音频到目标文件夹的程序仍在执行，但不影响
         while output_source_output is not True:
-            print(f'{output_source_output=}')
+            if self._exit(): return
             time.sleep(1)
         return True
 


### PR DESCRIPTION
## Summary
- `hebing()` 中 `os.chdir(cache_folder)` 仅在成功路径恢复 `os.chdir(ROOT_DIR)`，字幕嵌入异常时工作目录停留在 cache_folder，影响后续操作
- 将 `os.chdir(ROOT_DIR)` 移入现有 `try/except` 的 `finally` 块，确保始终恢复
- `while output_source_output is not True:` 循环缺少 `_exit()` 检查，后台线程失败时会无限挂起

## Test plan
- [ ] 正常合并流程不受影响
- [ ] 字幕嵌入异常时工作目录正确恢复
- [ ] 后台输出线程失败时不会无限挂起

🤖 Generated with [Claude Code](https://claude.com/claude-code)