### PR TITLE
Fix: IndexError on empty lists + resource leaks in recognition

### DIFF
--- a/videotrans/recognition/_ai302.py
+++ b/videotrans/recognition/_ai302.py
@@ -51,8 +51,10 @@ class AI302Recogn(BaseRecogn):
         prompt = settings.get(f'initial_prompt_{self.detect_language}')
 
         logger.debug(f'{prompt=}')
+        with open(self.audio_file, 'rb') as f:
+            audio_data = f.read()
         response = requests.post(url,
-                                 files={"file": open(self.audio_file, 'rb')},
+                                 files={"file": (Path(self.audio_file).name, audio_data)},
                                  data={
                                      "model": model_name,
                                      'response_format': 'verbose_json',
@@ -97,8 +99,10 @@ class AI302Recogn(BaseRecogn):
         err=''
         ok_nums=0
         for i, it in enumerate(raws):
+            with open(it['file'], 'rb') as f:
+                audio_chunk = f.read()
             response = requests.post(url,
-                 files={"file": open(it['file'], 'rb')},
+                 files={"file": (Path(it['file']).name, audio_chunk)},
                  data={
                      "model": model_name,
                      'response_format': 'json',
@@ -134,8 +138,10 @@ class AI302Recogn(BaseRecogn):
         prompt = settings.get(f'initial_prompt_{self.detect_language}')
 
 
+        with open(self.audio_file, 'rb') as f:
+            audio_data = f.read()
         response = requests.post(url,
-             files={"file":open(self.audio_file, 'rb')},
+             files={"file": (Path(self.audio_file).name, audio_data)},
              data={
                  "model": 'gpt-4o-transcribe-diarize',
                  'response_format': 'diarized_json',

--- a/videotrans/recognition/_glmasr.py
+++ b/videotrans/recognition/_glmasr.py
@@ -27,7 +27,9 @@ class GLMASRRecogn(BaseRecogn):
         err=''
         ok_nums=0
         for i, it in enumerate(raws):
-            files = { "file": (Path(it['file']).name, open(it['file'], "rb")) }
+            with open(it['file'], "rb") as f:
+                file_data = f.read()
+            files = { "file": (Path(it['file']).name, file_data) }
             payload = {
                 "model": "glm-asr-2512",
                 "stream": "false"

--- a/videotrans/task/_base.py
+++ b/videotrans/task/_base.py
@@ -113,7 +113,7 @@ class BaseTask(BaseCon):
 
     def _check_target_sub(self, source_srt_list, target_srt_list):
         import re, copy
-        if len(source_srt_list) == 1 or len(target_srt_list) == 1:
+        if len(source_srt_list) == 1 and len(target_srt_list) == 1:
             target_srt_list[0]['line'] = 1
             return target_srt_list[:1]
         source_len = len(source_srt_list)

--- a/videotrans/task/_rate.py
+++ b/videotrans/task/_rate.py
@@ -402,7 +402,7 @@ class SpeedRate:
         """计算策略"""
         tools.set_process(text="Calculating sync adjustments...", uuid=self.uuid)
         # 视频慢速，第0条字幕之前可能有无声音视频
-        if self.shoud_videorate and self.queue_tts[0]['start_time_source']>0:
+        if self.shoud_videorate and self.queue_tts and self.queue_tts[0]['start_time_source']>0:
             self.video_for_clips.append({
                     "start": 0,
                     "end": self.queue_tts[0]['start_time_source'],
@@ -584,6 +584,8 @@ class SpeedRate:
     def _concat_audio_aligned(self):
         logger.debug("[Audio] 开始对齐拼接...")
         audio_list = []
+        if not self.queue_tts:
+            return
         current_timeline = self.queue_tts[0]['start_time']
         if current_timeline>0:
             audio_list.append(self._create_silen_file("head_0", current_timeline))


### PR DESCRIPTION
## Summary
- `_base.py:_check_target_sub` 用 `or` 判断长度，当 source 有 1 条但 target 为空时 `target_srt_list[0]` 崩溃 → 改为 `and`
- `_rate.py` 两处 `queue_tts[0]` 未检查空列表，TTS 无输出时 IndexError → 添加空列表守卫
- `_glmasr.py` 和 `_ai302.py` 共 4 处 `open()` 传入 requests.files 后未关闭，循环处理音频分片时句柄泄漏 → 改为先 read 再传 bytes

## Test plan
- [ ] 翻译返回空结果时不崩溃
- [ ] TTS 无输出时对齐阶段不崩溃
- [ ] GLM ASR 和 302.ai ASR 功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)