### PR TITLE
Fix: add empty choices guard to all OpenAI-compatible translators

### DIFF
--- a/videotrans/translator/_azure.py
+++ b/videotrans/translator/_azure.py
@@ -52,7 +52,7 @@ class AzureGPT(BaseTrans):
             temperature=float(settings.get('aitrans_temperature',0.2)),
         )
         logger.debug(f'[AzureGPT]返回响应:{response=}')
-        if not hasattr(response,'choices'):
+        if not hasattr(response,'choices') or not response.choices:
             raise RuntimeError(str(response))
         
         if response.choices[0].finish_reason=='length':

--- a/videotrans/translator/_chatgpt.py
+++ b/videotrans/translator/_chatgpt.py
@@ -157,7 +157,7 @@ class ChatGPT(BaseTrans):
         )
         logger.debug(f'[chatGPT]响应:{response=}')
         result = ""
-        if not hasattr(response,'choices'):
+        if not hasattr(response,'choices') or not response.choices:
             raise RuntimeError(str(response))
         
         if response.choices[0].finish_reason=='length':

--- a/videotrans/translator/_deepseek.py
+++ b/videotrans/translator/_deepseek.py
@@ -60,7 +60,7 @@ class DeepSeek(BaseTrans):
 
         logger.debug(f'[deepseek]响应:{response=}')
         result = ""
-        if not hasattr(response,'choices'):
+        if not hasattr(response,'choices') or not response.choices:
             raise RuntimeError(str(response))
         if response.choices[0].finish_reason=='length':
             raise LengthFinishReasonError(completion=response)

--- a/videotrans/translator/_localllm.py
+++ b/videotrans/translator/_localllm.py
@@ -60,7 +60,7 @@ class LocalLLM(BaseTrans):
         if isinstance(response, str):
             raise RuntimeError(f'{response=}')
         
-        if not hasattr(response,'choices'):
+        if not hasattr(response,'choices') or not response.choices:
             raise RuntimeError(str(response))
         if response.choices[0].finish_reason=='length':
             raise LengthFinishReasonError(completion=response)    

--- a/videotrans/translator/_minimax.py
+++ b/videotrans/translator/_minimax.py
@@ -63,7 +63,7 @@ class MiniMax(BaseTrans):
 
         logger.debug(f'[minimax]响应:{response=}')
         result = ""
-        if not hasattr(response, 'choices'):
+        if not hasattr(response, 'choices') or not response.choices:
             raise RuntimeError(str(response))
         if response.choices[0].finish_reason == 'length':
             raise LengthFinishReasonError(completion=response)

--- a/videotrans/translator/_openrouter.py
+++ b/videotrans/translator/_openrouter.py
@@ -56,7 +56,7 @@ class OpenRouter(BaseTrans):
             temperature=float(settings.get('aitrans_temperature',0.2)),
             max_tokens=int(params.get('openrouter_max_tokens',8192))
         )
-        if not hasattr(response,'choices'):
+        if not hasattr(response,'choices') or not response.choices:
             raise RuntimeError(str(response))
         if response.choices[0].finish_reason=='length':
             raise LengthFinishReasonError(completion=response)

--- a/videotrans/translator/_siliconflow.py
+++ b/videotrans/translator/_siliconflow.py
@@ -49,7 +49,7 @@ class SILICONFLOW(BaseTrans):
         )
 
         logger.debug(f'[siliconflow]响应:{response=}')
-        if not hasattr(response,'choices'):
+        if not hasattr(response,'choices') or not response.choices:
             raise RuntimeError(str(response))
         if response.choices[0].finish_reason=='length':
             raise LengthFinishReasonError(completion=response)

--- a/videotrans/translator/_xiaomi.py
+++ b/videotrans/translator/_xiaomi.py
@@ -61,7 +61,7 @@ class XiaoMi(BaseTrans):
 
         logger.debug(f'[xiaomi]响应:{response=}')
         result = ""
-        if not hasattr(response,'choices'):
+        if not hasattr(response,'choices') or not response.choices:
             raise RuntimeError(str(response))
         if response.choices[0].finish_reason=='length':
             raise LengthFinishReasonError(completion=response)

--- a/videotrans/translator/_zhipuai.py
+++ b/videotrans/translator/_zhipuai.py
@@ -47,7 +47,7 @@ class ZhipuAI(BaseTrans):
         )
 
         logger.debug(f'[zhipuai]响应:{response=}')
-        if not hasattr(response,'choices'):
+        if not hasattr(response,'choices') or not response.choices:
             raise RuntimeError(str(response))
         result = ""
         if response.choices[0].finish_reason=='length':


### PR DESCRIPTION
## Summary
- 所有使用 OpenAI 兼容 API 的翻译模块（10 个文件）仅检查 `hasattr(response, 'choices')` 但未检查 `choices` 是否为空列表
- 当 API 返回 `choices=[]` 时，`choices[0]` 会抛出 IndexError
- 统一添加 `or not response.choices` 守卫，与 `_chatgpt.py:68` 中已有的正确模式一致

## 受影响文件
`_chatgpt.py` `_deepseek.py` `_azure.py` `_openrouter.py` `_minimax.py` `_siliconflow.py` `_xiaomi.py` `_localllm.py` `_zhipuai.py`

## Test plan
- [ ] 各翻译渠道正常使用不受影响
- [ ] API 返回空 choices 时给出明确错误而非 IndexError

🤖 Generated with [Claude Code](https://claude.com/claude-code)