### PR TITLE
Fix: _fix_post IndexError when previous subtitle text is empty

### DIFF
--- a/videotrans/recognition/_base.py
+++ b/videotrans/recognition/_base.py
@@ -196,6 +196,9 @@ class BaseRecogn(BaseCon):
                 post_srt_raws.append(it)
             else:
                 # 小于1s
+                if not post_srt_raws:
+                    post_srt_raws.append(it)
+                    continue
                 prev_diff = it['start_time'] - post_srt_raws[-1]['end_time']
                 next_diff = srt_list[idx + 1]['start_time'] - it['end_time']
                 # 前面不是标点结束，而当前是标点结束
@@ -258,7 +261,7 @@ class BaseRecogn(BaseCon):
                 continue
 
             # 上个字幕末尾有标点
-            if post_srt_raws[i - 1]['text'][-1] in self.flag:
+            if not post_srt_raws[i - 1]['text'] or post_srt_raws[i - 1]['text'][-1] in self.flag:
                 continue
             if not self.is_cjk and len(t[0].strip().split(' ')) > 3:
                 continue


### PR DESCRIPTION
## Summary
- `_fix_post()` 合并短字幕时，如果前面所有字幕都被过滤（空文本），`post_srt_raws[-1]` 在空列表上 IndexError → 添加空列表守卫直接 append
- 标点分割循环中，`it['text']` 可能被设为 `''`（全是标点时），后续循环访问 `post_srt_raws[i-1]['text'][-1]` 时 IndexError → 添加空文本检查

## Test plan
- [ ] 正常字幕识别不受影响
- [ ] ASR 返回全标点文本时不崩溃
- [ ] 第一条字幕为空时后续合并不崩溃

🤖 Generated with [Claude Code](https://claude.com/claude-code)