### PR TITLE
Fix: bare raise without active exception in LLM re-segment

### DIFF
--- a/videotrans/task/_speech2text.py
+++ b/videotrans/task/_speech2text.py
@@ -247,7 +247,7 @@ class SpeechToText(BaseTask):
                         self.source_srt_list = srt_list
                         self._save_srt_target(self.source_srt_list, self.cfg.target_sub)
                     else:
-                        raise
+                        raise RuntimeError('LLM re-segment result too short or empty')
                 except Exception as e:
                     self._signal(text=tr("Re-segmenting Error"))
                     logger.warning(f"重新断句失败[except]，已恢复原样 {e}")

--- a/videotrans/task/trans_create.py
+++ b/videotrans/task/trans_create.py
@@ -450,7 +450,7 @@ class TransCreate(BaseTask):
                     shutil.copy2(self.cfg.source_sub, f'{self.cfg.source_sub}-No-{tr("LLM Rephrase")}.srt')
                     self._save_srt_target(self.source_srt_list, self.cfg.source_sub)
                 else:
-                    raise
+                    raise RuntimeError('LLM re-segment result too short or empty')
             except Exception as e:
                 self._signal(text=tr("Re-segmenting Error"))
                 logger.warning(f"重新断句失败[except]，已恢复原样 {e}")


### PR DESCRIPTION
## Summary
- Fix bare `raise` in `try` block (not inside `except`) in both `_speech2text.py` and `trans_create.py`
- When LLM re-segmentation returns too few results, `raise` without an active exception causes `RuntimeError: No active exception to re-raise`
- Replace with explicit `RuntimeError('LLM re-segment result too short or empty')` so the outer `except Exception as e` can properly log the failure reason

## Bug details
Both files have identical copy-pasted code:
```python
try:
    srt_list = ob.llm_segment(...)
    if srt_list and len(srt_list) > len(self.source_srt_list) / 2:
        ...
    else:
        raise  # ← BUG: no active exception, crashes with RuntimeError
except Exception as e:
    logger.warning(f"重新断句失败 {e}")
```

When `srt_list` is empty or too short, `raise` executes inside the `try` block where there's no caught exception. Python raises `RuntimeError: No active exception to re-raise` instead of logging a meaningful failure message.

## Test plan
- [x] Verified both files have identical pattern and applied same fix
- [x] RuntimeError is properly caught by the outer `except Exception as e` handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)