### PR TITLE
Fix: AttributeError when previewing MossTTS voices

### DIFF
--- a/videotrans/util/help_role.py
+++ b/videotrans/util/help_role.py
@@ -448,6 +448,22 @@ def get_clone_role(set_p=False):
 
 
 
+def get_mosstts_role_test_text(role_name: str, default_text: str = ''):
+    role = str(role_name or '').strip()
+    if not role or role in {'No', 'clone'}:
+        return default_text
+    local_role_map = get_f5tts_role()
+    if role in local_role_map:
+        return local_role_map[role].get('ref_text') or default_text
+    demo_role_map = get_mosstts_demo_map()
+    if role in demo_role_map:
+        preset_test_text = str(params.get('moss_tts_preset_test_text', '') or '').strip()
+        if preset_test_text:
+            return preset_test_text
+        return demo_role_map[role].get('text') or default_text
+    return default_text
+
+
 def show_refaudio_win():
     from videotrans.component.set_form import RefaudioForm
     dialog = RefaudioForm()


### PR DESCRIPTION
## Summary
- `get_mosstts_role_test_text()` was removed in commit 011a6e73 (reference audio settings merge) but is still called in 3 places, causing `AttributeError` at runtime when a user clicks "Listen" to preview a MossTTS voice role.
- Restored the function using `get_f5tts_role()` (the new unified role getter) instead of the removed `get_mosstts_local_role_map()`.

## Affected callers
- `videotrans/winform/fn_peiyinrole.py:132`
- `videotrans/winform/fn_peiyin.py:263`
- `videotrans/mainwin/_actions_sub.py:515`

## Reproduction
1. Select MossTTS as TTS engine
2. Choose a voice role
3. Click "Listen" button
4. `AttributeError: module 'videotrans.util.tools' has no attribute 'get_mosstts_role_test_text'`

## Test plan
- [ ] Verify MossTTS voice preview works without crash
- [ ] Verify other TTS engines' voice preview still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)