### PR TITLE
Fix: crash in 7 TTS providers when no reference audio configured

### DIFF
--- a/videotrans/util/help_role.py
+++ b/videotrans/util/help_role.py
@@ -340,7 +340,7 @@ def get_qwenttslocal_rolelist():
         "Ono_anna":"Ono_anna",
         "Sohee":"Sohee"
     }
-    return get_f5tts_role()|voices
+    return (get_f5tts_role() or {})|voices
     
 
 def get_supertonic_rolelist():
@@ -418,7 +418,7 @@ def get_gptsovits_role():
 def get_f5tts_role():
 
     if not params.get('f5tts_role','').strip():
-        return
+        return {}
     rolelist = {"No":"No","clone":"clone"}
     for it in params.get('f5tts_role','').strip().split("\n"):
         tmp = it.strip().split('#')

--- a/videotrans/winform/chatterbox.py
+++ b/videotrans/winform/chatterbox.py
@@ -23,7 +23,10 @@ def openwin():
         params["chatterbox_exaggeration"] = min(max(float(winobj.exaggeration.text()), 0.25), 2.0)
         params.save()
         
-        _rolename = next(reversed(tools.get_f5tts_role().values()))
+        _f5roles = tools.get_f5tts_role()
+        if not _f5roles:
+            return tools.show_error(tr("Please set reference audio first"))
+        _rolename = next(reversed(_f5roles.values()))
         if not isinstance(_rolename,dict):
             return tools.show_error(tr("No reference audio {} exists",_rolename))
         rolename=_rolename.get('ref_audio')

--- a/videotrans/winform/cosyvoice.py
+++ b/videotrans/winform/cosyvoice.py
@@ -24,7 +24,10 @@ def openwin():
         
         params.save()
 
-        _rolename = next(reversed(tools.get_f5tts_role().values()))
+        _f5roles = tools.get_f5tts_role()
+        if not _f5roles:
+            return tools.show_error(tr("Please set reference audio first"))
+        _rolename = next(reversed(_f5roles.values()))
         if not isinstance(_rolename,dict):
             return tools.show_error(tr("No reference audio {} exists",_rolename))
         rolename=_rolename.get('ref_audio')

--- a/videotrans/winform/f5tts.py
+++ b/videotrans/winform/f5tts.py
@@ -34,7 +34,10 @@ def openwin(init=False):
         params["indextts_prompt"] = winobj.indextts_prompt.text()
         params.save()
         
-        _rolename = next(reversed(tools.get_f5tts_role().values()))
+        _f5roles = tools.get_f5tts_role()
+        if not _f5roles:
+            return tools.show_error(tr("Please set reference audio first"))
+        _rolename = next(reversed(_f5roles.values()))
         if not isinstance(_rolename,dict):
             return tools.show_error(tr("No reference audio {} exists",_rolename))
         rolename=_rolename.get('ref_audio')

--- a/videotrans/winform/fishtts.py
+++ b/videotrans/winform/fishtts.py
@@ -15,7 +15,10 @@ def openwin():
         url = winobj.api_url.text().strip()
         if not url.startswith('http'):
             url = 'http://' + url
-        _rolename = next(reversed(tools.get_f5tts_role().values()))
+        _f5roles = tools.get_f5tts_role()
+        if not _f5roles:
+            return tools.show_error(tr("Please set reference audio first"))
+        _rolename = next(reversed(_f5roles.values()))
         if not isinstance(_rolename,dict):
             return tools.show_error(tr("No reference audio {} exists",_rolename))
         rolename=_rolename.get('ref_audio')

--- a/videotrans/winform/mosstts.py
+++ b/videotrans/winform/mosstts.py
@@ -39,7 +39,10 @@ def openwin():
         winobj.local_test_btn.setText(tr('Testing...'))
         _sync_params(force_refresh_roles=True)
 
-        _rolename = next(reversed(tools.get_f5tts_role().values()))
+        _f5roles = tools.get_f5tts_role()
+        if not _f5roles:
+            return tools.show_error(tr("Please set reference audio first"))
+        _rolename = next(reversed(_f5roles.values()))
         if not isinstance(_rolename,dict):
             return tools.show_error(tr("No reference audio {} exists",_rolename))
         rolename=_rolename.get('ref_audio')

--- a/videotrans/winform/omnivoice.py
+++ b/videotrans/winform/omnivoice.py
@@ -22,7 +22,10 @@ def openwin():
         
         params.save()
 
-        _rolename = next(reversed(tools.get_f5tts_role().values()))
+        _f5roles = tools.get_f5tts_role()
+        if not _f5roles:
+            return tools.show_error(tr("Please set reference audio first"))
+        _rolename = next(reversed(_f5roles.values()))
         if not isinstance(_rolename, dict):
             return tools.show_error(tr("No reference audio {} exists",_rolename))
         rolename = _rolename.get('ref_audio')

--- a/videotrans/winform/qwenttslocal.py
+++ b/videotrans/winform/qwenttslocal.py
@@ -15,7 +15,10 @@ def openwin():
         instruct_text = winobj.instruct_text.text()
         params["qwenttslocal_prompt"] = instruct_text
         params.save()
-        _rolename = next(reversed(tools.get_f5tts_role().values()))
+        _f5roles = tools.get_f5tts_role()
+        if not _f5roles:
+            return tools.show_error(tr("Please set reference audio first"))
+        _rolename = next(reversed(_f5roles.values()))
         if not isinstance(_rolename,dict):
             return tools.show_error(tr("No reference audio {} exists",_rolename))
         rolename=_rolename.get('ref_audio')


### PR DESCRIPTION
## Summary
- `get_f5tts_role()` returned `None` when the `f5tts_role` parameter was empty, but commit 011a6e73 introduced callers that call `.values()`, `.keys()`, or `dict | dict` merge on the result without None guards.
- This causes `AttributeError` or `TypeError` when clicking "Test" on any of 7 TTS provider config dialogs without having reference audio configured.

## Root cause
`get_f5tts_role()` line 421 had `return` (returns `None`) when no roles are configured.

## Fixes
1. **`help_role.py`**: Changed `return` to `return {}` so callers always get a dict
2. **`help_role.py`**: Added `or {}` guard in `get_qwenttslocal_rolelist()` for the dict merge
3. **7 winform files**: Added empty dict guard before `next(reversed(...))` calls

## Affected providers
ChatterBox, OmniVoice, MossTTS, F5TTS, CosyVoice, QwenTTS-Local, FishTTS

## Reproduction
1. Open any TTS provider config (e.g., OmniVoice)
2. Set URL but do NOT configure any reference audio
3. Click "Test" button
4. `AttributeError: 'NoneType' object has no attribute 'values'`

## Test plan
- [ ] Verify "Test" button shows proper error message when no reference audio is set
- [ ] Verify "Test" button works correctly when reference audio is configured
- [ ] Verify all 7 TTS providers behave consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)