### PR TITLE
Fix: division by zero, temp file leak, and voice role dropdown bugs

### DIFF
--- a/videotrans/mainwin/_main_win.py
+++ b/videotrans/mainwin/_main_win.py
@@ -425,12 +425,13 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         tts_type = int(params.get('tts_type', 0))
         self.voice_role.clear()
         if tts_type == tts.CLONE_VOICE_TTS:
-            self.voice_role.addItems(params.get("clone_voicelist", ''))
+            self.voice_role.addItems(params.get("clone_voicelist", ["clone"]))
             run_in_threadpool(tools.get_clone_role)
         elif tts_type == tts.CHATTTS:
             self.voice_role.addItems(['No'] + list(settings.ChatTTS_voicelist))
         elif tts_type == tts.TTS_API:
-            self.voice_role.addItems(params.get('ttsapi_voice_role', '').strip().split(','))
+            rolelist = params.get('ttsapi_voice_role', '').strip()
+            self.voice_role.addItems(rolelist.split(',') if rolelist else [])
         elif tts_type == tts.GPTSOVITS_TTS:
             rolelist = tools.get_gptsovits_role()
             self.voice_role.addItems(list(rolelist.keys()) if rolelist else ['GPT-SoVITS'])
@@ -446,7 +447,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self.voice_role.addItems(rolelist)
         elif tts_type == tts.OPENAI_TTS:
             rolelist = params.get('openaitts_role', '')
-            self.voice_role.addItems(['No'] + rolelist.split(','))
+            self.voice_role.addItems(['No'] + (rolelist.split(',') if rolelist else []))
         elif tts_type == tts.XAI_TTS:
             self.voice_role.addItems(['No'] + contants.XAITTS_ROLES.split(','))
         elif tts_type == tts.XIAOMI_TTS:
@@ -459,7 +460,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             self.voice_role.addItems(rolelist)
         elif tts_type == tts.GEMINI_TTS:
             rolelist = params.get('gemini_ttsrole', '')
-            self.voice_role.addItems(['No'] + rolelist.split(','))
+            self.voice_role.addItems(['No'] + (rolelist.split(',') if rolelist else []))
         elif self.win_action.change_by_lang(tts_type):
             self.voice_role.clear()
 

--- a/videotrans/process/prepare_audio.py
+++ b/videotrans/process/prepare_audio.py
@@ -222,6 +222,7 @@ def remove_noise(*, input_file, output_file,  is_cuda=False, logs_file=None, dev
         tmp_name = Path(output_file).parent.as_posix() + f'/noise-{time.time()}.wav'
         sf.write(tmp_name, denoised.samples, denoised.sample_rate)
         tools.runffmpeg(['-y', '-i', tmp_name, '-af', "volume=1.5", output_file])
+        Path(tmp_name).unlink(missing_ok=True)
         logger.info(f'降噪成功完成，耗时:{int(time.time() - _st)}s')
         return output_file, None
     except Exception as e:
@@ -660,7 +661,7 @@ def built_speakers(*, input_file, subtitles, num_speakers=-1, language="zh",  lo
         return sherpa_onnx.OfflineSpeakerDiarization(_cf)
 
     def _progress_callback(num_processed_chunk: int, num_total_chunks: int) -> int:
-        progress = num_processed_chunk / num_total_chunks * 100
+        progress = num_processed_chunk / num_total_chunks * 100 if num_total_chunks > 0 else 0
         return 0
 
     def _get_diariz():


### PR DESCRIPTION
## Summary
- Guard `_progress_callback` against `num_total_chunks == 0` causing ZeroDivisionError during speaker diarization
- Clean up temporary WAV file after ffmpeg conversion in `remove_noise()` to prevent file accumulation
- Fix `clone_voicelist` fallback from `''` (string) to `["clone"]` (list) matching the config default type
- Prevent blank dropdown items from `''.split(',')` in TTS API, OpenAI, and Gemini voice role dropdowns

## Test plan
- [ ] Verify speaker diarization doesn't crash with empty audio (division by zero fix)
- [ ] Confirm no orphaned `noise-*.wav` files after denoising
- [ ] Check Clone voice role dropdown shows ["clone"] when config missing
- [ ] Verify TTS API / OpenAI / Gemini dropdowns have no blank items when roles are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)