### PR TITLE
Fix: copy-paste pitch bug, wrong exception type, and GPT-SoVITS None return

### DIFF
--- a/videotrans/mainwin/_actions.py
+++ b/videotrans/mainwin/_actions.py
@@ -752,7 +752,7 @@ class WinAction(WinActionSub):
             try:
                 if v['uuid'] in app_cfg.uuid_logs_queue:
                     del app_cfg.uuid_logs_queue[v['uuid']]
-            except ValueError:
+            except KeyError:
                 pass
 
     # 添加进度条

--- a/videotrans/mainwin/_actions_sub.py
+++ b/videotrans/mainwin/_actions_sub.py
@@ -351,7 +351,9 @@ class WinActionSub:
     # 保存目录
     def get_save_dir(self):
         dirname = QtWidgets.QFileDialog.getExistingDirectory(self.main, tr('selectsavedir'),params.get('last_opendir',''))
-        dirname = Path(dirname).as_posix()
+        dirname = Path(dirname).as_posix() if dirname else ''
+        if not dirname:
+            return
         self.main.target_dir = dirname
         self.main.btn_save_dir.setToolTip(self.main.target_dir)
 
@@ -525,7 +527,7 @@ class WinActionSub:
         volume = int(self.main.volume_rate.value())
         volume = f'+{volume}%' if volume >= 0 else f'{volume}%'
         pitch = int(self.main.pitch_rate.value())
-        pitch = f'+{pitch}Hz' if pitch >= 0 else f'{volume}Hz'
+        pitch = f'+{pitch}Hz' if pitch >= 0 else f'{pitch}Hz'
 
         voice_file = f"{voice_dir}/{time.time()}.wav"
         obj = {

--- a/videotrans/util/help_role.py
+++ b/videotrans/util/help_role.py
@@ -405,7 +405,7 @@ def get_kokoro_rolelist():
 def get_gptsovits_role():
 
     if not params.get('gptsovits_role','').strip():
-        return None
+        return {}
     rolelist = {"No":"No","clone":"clone"}
     for it in params.get('gptsovits_role','').strip().split("\n"):
         tmp = it.strip().split('#')


### PR DESCRIPTION
## Summary
- Fix copy-paste bug in `_actions_sub.py:528` where negative pitch values used `volume` instead of `pitch` (e.g., `-5Hz` would show the volume value)
- Fix `_actions.py:755` where `except ValueError` should be `except KeyError` for `del dict[key]` — the original exception type never matches, so the KeyError was unhandled
- Fix `get_gptsovits_role()` returning `None` instead of `{}`, causing `AttributeError` on `.keys()` in callers (same pattern as `get_f5tts_role()` fix in PR #1055)
- Guard against cancelled save directory dialog setting `target_dir` to `"."` (current working directory)

## Test plan
- [ ] Set a negative pitch value and verify the correct pitch (not volume) is applied
- [ ] Verify `_clear_task()` properly handles missing UUID keys
- [ ] Confirm GPT-SoVITS voice role dropdown works when no roles configured
- [ ] Cancel the save directory dialog and verify target_dir is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)