### PR TITLE
Fix: params KeyError and torch import crash in fn_peiyinrole.py

### DIFF
--- a/videotrans/winform/fn_peiyinrole.py
+++ b/videotrans/winform/fn_peiyinrole.py
@@ -336,9 +336,10 @@ def openwin():
         elif type == tts.CAMB_TTS:
             role_list = tools.get_camb_role()
         elif type == tts.CLONE_VOICE_TTS:
-            role_list.extend([it for it in params["clone_voicelist"] if it != 'clone'])
+            role_list.extend([it for it in params.get("clone_voicelist", []) if it != 'clone'])
         elif type == tts.TTS_API:
-            role_list=params['ttsapi_voice_role'].split(",")
+            ttsapi_role = params.get('ttsapi_voice_role', '')
+            role_list = ttsapi_role.split(",") if ttsapi_role else []
         elif type == tts.GPTSOVITS_TTS:
             role_list = list(tools.get_gptsovits_role().keys())
         elif type in [tts.F5_TTS, tts.INDEX_TTS, tts.SPARK_TTS, tts.VOXCPM_TTS,
@@ -441,7 +442,13 @@ def openwin():
     def check_cuda(state):
         # 选中如果无效，则取消
         if state:
-            import torch
+            try:
+                import torch
+            except ImportError:
+                tools.show_error(tr('nocuda'))
+                winobj.is_cuda.setChecked(False)
+                winobj.is_cuda.setDisabled(True)
+                return False
             if not torch.cuda.is_available():
                 tools.show_error(tr('nocuda'))
                 winobj.is_cuda.setChecked(False)


### PR DESCRIPTION
## Summary
- Line 339: `params["clone_voicelist"]` raises KeyError when key not set, changed to `params.get()` with empty list default
- Line 341: `params['ttsapi_voice_role']` raises KeyError/AttributeError when key missing or None, added `.get()` with empty string default and None guard
- Line 444: `import torch` crashes UI when PyTorch not installed, added try/except ImportError

## Test plan
- [ ] Select CLONE_VOICE_TTS type without clone_voicelist configured — should show empty role list instead of crash
- [ ] Select TTS_API type without ttsapi_voice_role configured — should show empty role list instead of crash
- [ ] Toggle CUDA checkbox without PyTorch — should show error dialog