### PR TITLE
Fix: infinite progress loop and thread leak in fn_vas.py

### DIFF
--- a/videotrans/winform/fn_vas.py
+++ b/videotrans/winform/fn_vas.py
@@ -75,10 +75,14 @@ def openwin():
         #
         def hebing_pro(self, protxt, video_time=0):
             percent = 0
+            timeout = 0
             while 1:
                 if percent >= 100 or self.is_end:
                     return
-                content = tools.read_last_n_lines(protxt)    
+                timeout += 1
+                if timeout > 3600:
+                    return
+                content = tools.read_last_n_lines(protxt)
                 if not content:
                     time.sleep(1)
                     continue
@@ -264,6 +268,7 @@ def openwin():
                 self.post(type='ok', text=self.file)
                 self.is_end=True
             except Exception as e:
+                self.is_end = True
                 from videotrans.configure._except import get_msg_from_except
                 self.post(type='error', text=get_msg_from_except(e))
 


### PR DESCRIPTION
## Summary
- `hebing_pro()` had no timeout — if ffmpeg fails or the progress file is never written, the daemon thread loops forever polling a stale file. Added a 3600-second timeout counter to ensure the thread eventually exits.
- `except` block at line 266 did not set `self.is_end=True`, so the progress monitoring thread started at line 262 would never terminate on ffmpeg failure, causing a permanent thread leak.

## Test plan
- [ ] Run audio-video synthesis with a corrupt video file that causes ffmpeg to fail — verify progress thread exits instead of hanging
- [ ] Run normal audio-video synthesis — verify progress monitoring still works correctly