### PR TITLE
Fix: duplicate UUIDs in fn_fanyisrt.py translation task tracking

### DIFF
--- a/videotrans/winform/fn_fanyisrt.py
+++ b/videotrans/winform/fn_fanyisrt.py
@@ -136,7 +136,6 @@ def openwin():
         if winobj.save_source.isChecked():
             SOURCE_DIR = Path(video_list[0]['name']).parent.as_posix()
         for it in video_list:
-            uuid_list.append(it['uuid'])
             cfg={
                 "translate_type": translate_type,
                 "target_dir": SOURCE_DIR if SOURCE_DIR else RESULT_DIR,


### PR DESCRIPTION
## Summary
Same pattern as #1062 in fn_recogn.py — `uuid_list` was populated by list comprehension at line 135, then the for-loop at line 138-139 appended each UUID again, causing every UUID to appear twice in the tracking list passed to `SignThread`.

## Test plan
- [ ] Run batch subtitle translation with multiple files and verify progress tracking reports correct count