### PR TITLE
Fix: WorkerDiariz silently swallows failures and routes bad tasks forward

### DIFF
--- a/videotrans/task/job.py
+++ b/videotrans/task/job.py
@@ -139,16 +139,24 @@ class WorkerDiariz(QThread):
                 trk.diariz()
             except Exception as e:
                 logger.exception(e, exc_info=True)
-            finally:
-                # 如果需要识翻译,则插入翻译队列，否则就行判断配音队列，都不吻合则插入最终队列
-                if trk.shoud_trans:
-                    app_cfg.trans_queue.put_nowait(trk)
-                elif trk.shoud_dubbing:
-                    app_cfg.dubb_queue.put_nowait(trk)
-                elif trk.shoud_hebing:
-                    app_cfg.assemb_queue.put_nowait(trk)
-                else:
-                    app_cfg.taskdone_queue.put_nowait(trk)
+                except_msg = get_msg_from_except(e)
+                detail_back = (traceback.format_exc()).strip()
+                if not except_msg:
+                    except_msg = detail_back.split("\n")[-1]
+                msg = f'{tr("yuchulichucuo")} {except_msg}\n{detail_back}\n{trk.cfg}'
+                set_process(text=msg, type='error', uuid=trk.uuid)
+                tools.send_notification(f'Error:{e}', f'{trk.cfg.basename}')
+                app_cfg.taskdone_queue.put_nowait(trk)
+                continue
+            # 如果需要识翻译,则插入翻译队列，否则就行判断配音队列，都不吻合则插入最终队列
+            if trk.shoud_trans:
+                app_cfg.trans_queue.put_nowait(trk)
+            elif trk.shoud_dubbing:
+                app_cfg.dubb_queue.put_nowait(trk)
+            elif trk.shoud_hebing:
+                app_cfg.assemb_queue.put_nowait(trk)
+            else:
+                app_cfg.taskdone_queue.put_nowait(trk)
 
 
 


### PR DESCRIPTION
## Summary
WorkerDiariz caught diarization exceptions but only logged them — no user notification (`set_process`/`send_notification`), and the `finally` block still routed the failed task to the next pipeline stage (translation/dubbing/assembly) as if it succeeded. This caused silently corrupted output where diarization failures propagated downstream.

Fix: Added proper error handling matching `WorkerPreprocess` pattern:
- Set error message via `set_process(type='error')` with traceback
- Send desktop notification
- Route failed task to `taskdone_queue` instead of next pipeline stage
- Removed `finally` block to prevent unconditional forwarding on error

## Test plan
- [ ] Trigger a diarization failure (e.g. invalid audio file) and verify user gets error notification instead of task silently continuing with no speaker labels