### PR TITLE
Fix: AttributeError crash in OpenAI exception handlers when body is None

### DIFF
--- a/videotrans/configure/_except.py
+++ b/videotrans/configure/_except.py
@@ -212,19 +212,19 @@ def get_msg_from_except(ex):
     exception_handlers = {
         # === 认证和权限问题 ===
         AuthenticationError: lambda e: (
-            f"API密钥错误，请检查密钥是否正确 {e.body.get('message')}" if lang == 'zh'
-            else  e.body.get('message')
+            f"API密钥错误，请检查密钥是否正确 {e.body.get('message') if hasattr(e.body, 'get') else str(e)}" if lang == 'zh'
+            else  e.body.get('message') if hasattr(e.body, 'get') else str(e)
         ),
 
         PermissionDeniedError: lambda e: (
-            f"当前密钥没有访问权限，请检查权限设置 {e.body.get('message')}" if lang == 'zh'
-            else  e.message
+            f"当前密钥没有访问权限，请检查权限设置 {e.body.get('message') if hasattr(e.body, 'get') else str(e)}" if lang == 'zh'
+            else  e.message if hasattr(e, 'message') else str(e)
         ),
 
         # === 频率限制 ===
         RateLimitError: lambda e: (
-            f"请求过于频繁或余额不足：{e.body.get('message')}" if lang == 'zh'
-            else e.body.get('message')
+            f"请求过于频繁或余额不足：{e.body.get('message') if hasattr(e.body, 'get') else str(e)}" if lang == 'zh'
+            else e.body.get('message') if hasattr(e.body, 'get') else str(e)
         ),
         # === 资源不存在问题 ===
         # === 请求参数问题 ===


### PR DESCRIPTION
## Summary
AuthenticationError, PermissionDeniedError, and RateLimitError handlers in `get_msg_from_except()` called `e.body.get('message')` without checking if `body` is None. When the API returns an empty response body (malformed HTTP, connection interrupted mid-response), this crashes with `AttributeError: 'NoneType' object has no attribute 'get'`.

The existing handlers for InternalServerError/NotFoundError/BadRequestError at line 232 already used `hasattr(e.body, 'get')` guards — this PR applies the same pattern to the three unprotected handlers.

## Test plan
- [ ] Trigger an OpenAI API call with an invalid/expired key that returns empty body — should show readable error message instead of AttributeError