### PR TITLE
Fix: speaker diarization silently fails + volume temp file leak in trans_create.py

### DIFF
--- a/videotrans/task/trans_create.py
+++ b/videotrans/task/trans_create.py
@@ -665,8 +665,8 @@ class TransCreate(BaseTask):
                 logger.debug('分离说话人成功完成')
                 shutil.copy2(self.cfg.cache_folder + "/speaker.json", self.cfg.target_dir + "/speaker.json")
             self._signal(text=tr('separating speakers end'))
-        except:
-            pass
+        except Exception as e:
+            logger.warning(f'Speaker diarization failed, skipping: {e}')
 
     # 翻译字幕文件
     def trans(self) -> None:
@@ -815,8 +815,9 @@ class TransCreate(BaseTask):
                     tools.runffmpeg(['-y', '-i', os.path.basename(self.cfg.target_wav), '-af', f"volume={volume}",
                                      os.path.basename(tmp_name)], cmd_dir=self.cfg.cache_folder)
                     shutil.copy2(tmp_name, self.cfg.target_wav)
-            except:
-                pass
+                    Path(tmp_name).unlink(missing_ok=True)
+            except Exception as e:
+                logger.warning(f'Volume adjustment failed: {e}')
 
         self._signal(text=tr('Alignment phase complete, awaiting the next step'))
 


### PR DESCRIPTION
## Summary
- Line 668: bare `except: pass` in `diariz()` swallowed all errors with zero user feedback. User explicitly enabled speaker diarization but if it failed (missing model, CUDA OOM, network error), the pipeline silently continued as if diarization was never requested. Fix: changed to `except Exception as e:` with `logger.warning()`.
- Line 818: volume adjustment left temp file on success and silently swallowed errors. Added `Path(tmp_name).unlink()` and changed to `except Exception as e:` with `logger.warning()`.

## Test plan
- [ ] Enable speaker diarization with an invalid/missing model — should see warning in logs instead of silent skip
- [ ] Run volume adjustment and verify temp files are cleaned up after successful ffmpeg conversion