### PR TITLE
Fix _actions.py IndexError, return-in-finally, and separate_worker timeout

### DIFF
--- a/videotrans/mainwin/_actions.py
+++ b/videotrans/mainwin/_actions.py
@@ -225,8 +225,10 @@ class WinAction(WinActionSub):
         elif type == tts.CLONE_VOICE_TTS:
             self.main.voice_role.clear()
             self.main.current_rolelist = params.get("clone_voicelist",'')
-            if self.main.current_rolelist[0]!='No':
+            if self.main.current_rolelist and self.main.current_rolelist[0]!='No':
                 self.main.current_rolelist.insert(0,'No')
+            elif not self.main.current_rolelist:
+                self.main.current_rolelist = ['No']
             self.main.voice_role.addItems(self.main.current_rolelist)
             run_in_threadpool(tools.get_clone_role)
         elif type == tts.CHATTTS:
@@ -343,12 +345,11 @@ class WinAction(WinActionSub):
                 content = Path(fname).read_text(encoding='utf-8')
             except UnicodeError:
                 content = Path(fname).read_text(encoding='gbk')
-            finally:
-                if content:
-                    self.main.subtitle_area.clear()
-                    self.main.subtitle_area.insertPlainText(content.strip())
-                else:
-                    return tools.show_error(tr('import src error'))
+            if content:
+                self.main.subtitle_area.clear()
+                self.main.subtitle_area.insertPlainText(content.strip())
+            else:
+                return tools.show_error(tr('import src error'))
 
     # 判断是否需要翻译
     def shound_translate(self):

--- a/videotrans/task/separate_worker.py
+++ b/videotrans/task/separate_worker.py
@@ -76,7 +76,7 @@ class SeparateWorker(QThread):
                         vocal_bgm,
                         **kw
                     )
-            rs,err=future.result()
+            rs,err=future.result(timeout=3600)
             if rs is False:
                 self.finish_event.emit(err)
         except Exception as e:


### PR DESCRIPTION
## Summary
- Fix `current_rolelist[0]` IndexError when `clone_voicelist` is empty in `set_voice_role()` — adds empty list guard with fallback to `['No']`
- Fix `return` inside `finally` block in `import_src()` — Pyright error that could mask exceptions during file reading
- Add `timeout=3600` to `future.result()` in `separate_worker.py` — prevents indefinite hang when vocal/background separation subprocess stalls

## Test plan
- [ ] Verify voice role dropdown doesn't crash when clone_voicelist is empty
- [ ] Verify subtitle import error handling works correctly without finally/return conflict
- [ ] Verify vocal separation times out gracefully after 1 hour instead of hanging forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)