### PR TITLE
Fix TTS: gptsovits IndexError on empty roledict, edgetts None role overwrite

### DIFF
--- a/videotrans/tts/_edgetts.py
+++ b/videotrans/tts/_edgetts.py
@@ -141,7 +141,9 @@ class EdgeTTS(BaseTTS):
         total_tasks = len(self.queue_tts)
         semaphore = asyncio.Semaphore(MAX_CONCURRENT_TASKS)
         for it in self.queue_tts:
-            it['role']=tools.get_edge_rolelist(it['role'],self.language)
+            role = tools.get_edge_rolelist(it['role'],self.language)
+            if role:
+                it['role'] = role
 
         worker_tasks = [
             asyncio.create_task(

--- a/videotrans/tts/_gptsovits.py
+++ b/videotrans/tts/_gptsovits.py
@@ -68,12 +68,14 @@ class GPTSoVITS(BaseTTS):
                         self.pad_audio= self.pad_audio if self.pad_audio else self._padforaudio(3000 if ms_ref<1500 else 1600)
                         
                         (ref_wav_audio+self.pad_audio).export(ref_wav,format="wav")
-                elif keys[-1]=='clone':
+                elif keys and keys[-1]=='clone':
                     # 无自定义参考音频，clone原音频时长不符合，失败
                     raise RuntimeError('No refer audio and origin audio duration not between 3-10s')
-                else:
+                elif keys:
                     # 克隆原音频失败，使用最后一个参考音频
                     data.update(roledict[keys[-1]])
+                else:
+                    raise RuntimeError('No reference audio available for voice cloning')
 
             if not data.get('refer_wav_path') and role !='clone':
                 raise StopRetry(message=tr("Must pass in the reference audio file path"))


### PR DESCRIPTION
## Summary
- Fix `keys[-1]` IndexError in `_gptsovits.py` when `get_gptsovits_role()` returns empty dict — adds truthiness check before list access in clone mode fallback path
- Fix `get_edge_rolelist()` None overwrite in `_edgetts.py` — only update `it['role']` when the lookup returns a valid value, preventing role from being replaced with None on locale mismatch

## Test plan
- [ ] Verify GPT-SoVITS doesn't crash when role list is empty during clone mode
- [ ] Verify EdgeTTS preserves original role when locale-based lookup fails
- [ ] Verify GPT-SoVITS clone mode raises clear error when no reference audio available

🤖 Generated with [Claude Code](https://claude.com/claude-code)