### PR TITLE
Fix _actions_sub.py pitch copy-paste bug and realtime_stt resource leak

### DIFF
--- a/videotrans/component/realtime_stt.py
+++ b/videotrans/component/realtime_stt.py
@@ -226,33 +226,34 @@ class Worker(QThread):
 
         self.running = True
         last_result = ""
-        while self.running:
-            samples, _ = mic_stream.read(self.samples_per_read)
-            samples_int16 = (samples * 32767).astype(np.int16)
-            wav_file.writeframes(samples_int16.tobytes())
+        try:
+            while self.running:
+                samples, _ = mic_stream.read(self.samples_per_read)
+                samples_int16 = (samples * 32767).astype(np.int16)
+                wav_file.writeframes(samples_int16.tobytes())
 
-            samples = samples.reshape(-1)
-            stream.accept_waveform(self.sample_rate, samples)
-            while recognizer.is_ready(stream):
-                recognizer.decode_stream(stream)
+                samples = samples.reshape(-1)
+                stream.accept_waveform(self.sample_rate, samples)
+                while recognizer.is_ready(stream):
+                    recognizer.decode_stream(stream)
 
-            is_endpoint = recognizer.is_endpoint(stream)
-            result = recognizer.get_result(stream)
+                is_endpoint = recognizer.is_endpoint(stream)
+                result = recognizer.get_result(stream)
 
-            if result != last_result:
-                self.new_word.emit(result)
-                last_result = result
+                if result != last_result:
+                    self.new_word.emit(result)
+                    last_result = result
 
-            if is_endpoint:
-                if result:
-                    punctuated = PUNCT_MODEL(result)
-                    txt_file.write(punctuated)
-                    self.new_segment.emit(punctuated)
-                recognizer.reset(stream)
-
-        mic_stream.stop()
-        wav_file.close()
-        txt_file.close()
+                if is_endpoint:
+                    if result:
+                        punctuated = PUNCT_MODEL(result)
+                        txt_file.write(punctuated)
+                        self.new_segment.emit(punctuated)
+                    recognizer.reset(stream)
+        finally:
+            mic_stream.stop()
+            wav_file.close()
+            txt_file.close()
 
 class DownloadModel(QThread):
     down = Signal(str)

--- a/videotrans/mainwin/_actions_sub.py
+++ b/videotrans/mainwin/_actions_sub.py
@@ -525,7 +525,7 @@ class WinActionSub:
         volume = int(self.main.volume_rate.value())
         volume = f'+{volume}%' if volume >= 0 else f'{volume}%'
         pitch = int(self.main.pitch_rate.value())
-        pitch = f'+{pitch}Hz' if pitch >= 0 else f'{volume}Hz'
+        pitch = f'+{pitch}Hz' if pitch >= 0 else f'{pitch}Hz'
 
         voice_file = f"{voice_dir}/{time.time()}.wav"
         obj = {


### PR DESCRIPTION
## Summary
- Fix copy-paste bug in `_actions_sub.py` line 528: negative pitch formatting used `volume` instead of `pitch` variable — identical pattern to the fn_peiyin.py fixes in PRs #1057 and #1060. This is the **third instance** of the same copy-paste bug found across the codebase.
- Fix resource leak in `realtime_stt.py`: wrap STT recording loop in try/finally to ensure `mic_stream`, `wav_file`, and `txt_file` are properly closed if the loop exits due to exception

## Test plan
- [ ] Verify negative pitch values are formatted correctly (e.g., `-5Hz` not wrong volume value)
- [ ] Verify realtime STT recording cleans up resources on unexpected termination

🤖 Generated with [Claude Code](https://claude.com/claude-code)