### PR TITLE
Fix textmatching temp file leak and editdubb crash on missing data

### DIFF
--- a/videotrans/component/onlyone_set_editdubb.py
+++ b/videotrans/component/onlyone_set_editdubb.py
@@ -54,7 +54,13 @@ class EditDubbingResultDialog(QDialog):
         self.parent = parent
         self.language = language
         self.cache_folder = cache_folder
-        self.queue_tts = json.loads(Path(f'{cache_folder}/queue_tts.json').read_text(encoding='utf-8'))
+        self.queue_tts = []
+        queue_tts_file = Path(f'{cache_folder}/queue_tts.json')
+        if queue_tts_file.exists():
+            try:
+                self.queue_tts = json.loads(queue_tts_file.read_text(encoding='utf-8'))
+            except (json.JSONDecodeError, OSError) as e:
+                logger.warning(f'Failed to load queue_tts.json: {e}')
 
         self.setWindowTitle(tr("Proofreading and dubbing - Re-dubbing"))
         self.setWindowIcon(QIcon(f"{ROOT_DIR}/videotrans/styles/icon.ico"))
@@ -516,7 +522,12 @@ class EditDubbingResultDialog(QDialog):
         """重配音完成回调"""
         print(f'{msg=}')
         if msg.startswith("ok:"):
-            idx = int(msg[3:])
+            try:
+                idx = int(msg[3:])
+            except ValueError:
+                return
+            if idx < 0 or idx >= len(self.queue_tts):
+                return
             item = self.queue_tts[idx]
             
             # 读取新文件时长

--- a/videotrans/component/textmatching.py
+++ b/videotrans/component/textmatching.py
@@ -136,20 +136,23 @@ class AlignmentWorker(QThread):
 
             self.log_signal.emit(tr("status_transcribing"))
             tempfile=f'{TEMP_DIR}/textmatching-{time.time()}.wav'
-            tools.conver_to_16k(self.audio_path,tempfile)
-            segments, info = model.transcribe(
-                  tempfile,
-                  vad_filter=True,
-                  condition_on_previous_text=False,
-                  word_timestamps=True,
-                  language=self.language,
-                  temperature=0.0,
-                  initial_prompt=settings.get(f'initial_prompt_{self.language}') if self.language != 'auto' else None,
-                beam_size=int(settings.get('beam_size', 5)),
-                best_of=int(settings.get('best_of', 5)),
-                repetition_penalty=float(settings.get('repetition_penalty', 1.0)),
-                compression_ratio_threshold=float(settings.get('compression_ratio_threshold', 2.2)),
-                )
+            try:
+                tools.conver_to_16k(self.audio_path,tempfile)
+                segments, info = model.transcribe(
+                      tempfile,
+                      vad_filter=True,
+                      condition_on_previous_text=False,
+                      word_timestamps=True,
+                      language=self.language,
+                      temperature=0.0,
+                      initial_prompt=settings.get(f'initial_prompt_{self.language}') if self.language != 'auto' else None,
+                    beam_size=int(settings.get('beam_size', 5)),
+                    best_of=int(settings.get('best_of', 5)),
+                    repetition_penalty=float(settings.get('repetition_penalty', 1.0)),
+                    compression_ratio_threshold=float(settings.get('compression_ratio_threshold', 2.2)),
+                    )
+            finally:
+                Path(tempfile).unlink(missing_ok=True)
 
             whisper_chars = []
             seg_count = 0


### PR DESCRIPTION
## Summary
- Fix temp file leak in `textmatching.py`: the 16kHz audio file created for Whisper transcription was never deleted after use — wrapped in try/finally with `Path.unlink(missing_ok=True)`
- Fix `FileNotFoundError` crash in `onlyone_set_editdubb.py` constructor when `queue_tts.json` doesn't exist or is corrupt — added file existence check and try/except with fallback to empty list
- Fix `IndexError` in `_on_redub_finished` callback when `msg` contains invalid index — added bounds check and ValueError guard

## Test plan
- [ ] Verify text matching tool cleans up temp audio file after transcription
- [ ] Verify edit dubb window opens without crash when cache is empty
- [ ] Verify redub callback handles malformed messages gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)