### PR TITLE
Fix downmodels IndexError on empty URLs and doubao ASR infinite loop

### DIFF
--- a/videotrans/component/downmodels.py
+++ b/videotrans/component/downmodels.py
@@ -140,6 +140,7 @@ class DownloadWorker(QThread):
         return os.path.basename(parsed.path)
 
     def run(self):
+        urls_to_process = []
         try:
             if app_cfg.proxy:
                 os.environ['HTTPS_PROXY']=app_cfg.proxy
@@ -148,8 +149,6 @@ class DownloadWorker(QThread):
             # 1. 解析任务类型
             target_dir = Path(self.task["dir"])
             target_dir.mkdir(parents=True, exist_ok=True)
-
-            urls_to_process = [] # List of (url, save_path, is_archive)
 
             # 情况 A: Faster Whisper (多个 URL)
             if "urls" in self.task:
@@ -280,20 +279,21 @@ class DownloadWorker(QThread):
             self.finished_signal.emit(False, "STOPPED")
         except Exception as e:
             msg=str(e)
-            # faster-whisper 模型 多个文件
-            if 'hf-mirror.com' in urls_to_process[0]['url'] or 'huggingface.co' in urls_to_process[0]['url']:
-                downurl=urls_to_process[0]['url'].split('/resolve/main')[0]+"/tree/main"
-                msg=f'{TRANS["xiazaishibai_shoudong"].format(downurl,self.task["dir"])}\n\n{msg}'
-                QApplication.clipboard().setText(downurl)
-            elif urls_to_process[0]['url'].endswith('.zip'):
-                # zip 文件
-                msg=TRANS['zip_xiazaishibai_shoudong'].format(urls_to_process[0]['url'],self.task.get('zip_folder',''),self.task['dir'])
-                QApplication.clipboard().setText(urls_to_process[0]['url'])
-            else:
-                # openai-whisper 模型，单个pt文件
-                msg=TRANS['pt_xiazaishibai_shoudong'].format(urls_to_process[0]['url'],self.task['name'],self.task['dir'])
-                QApplication.clipboard().setText(urls_to_process[0]['url'])
-            
+            if urls_to_process:
+                # faster-whisper 模型 多个文件
+                if 'hf-mirror.com' in urls_to_process[0]['url'] or 'huggingface.co' in urls_to_process[0]['url']:
+                    downurl=urls_to_process[0]['url'].split('/resolve/main')[0]+"/tree/main"
+                    msg=f'{TRANS["xiazaishibai_shoudong"].format(downurl,self.task["dir"])}\n\n{msg}'
+                    QApplication.clipboard().setText(downurl)
+                elif urls_to_process[0]['url'].endswith('.zip'):
+                    # zip 文件
+                    msg=TRANS['zip_xiazaishibai_shoudong'].format(urls_to_process[0]['url'],self.task.get('zip_folder',''),self.task['dir'])
+                    QApplication.clipboard().setText(urls_to_process[0]['url'])
+                else:
+                    # openai-whisper 模型，单个pt文件
+                    msg=TRANS['pt_xiazaishibai_shoudong'].format(urls_to_process[0]['url'],self.task['name'],self.task['dir'])
+                    QApplication.clipboard().setText(urls_to_process[0]['url'])
+
             self.finished_signal.emit(False, msg)
 
 # ==========================================

--- a/videotrans/recognition/_doubao.py
+++ b/videotrans/recognition/_doubao.py
@@ -73,6 +73,8 @@ class DoubaoRecogn(BaseRecogn):
             if self._exit():
                 return
             delay += 1
+            if delay > 3600:
+                raise RuntimeError('Doubao ASR task timed out after 1 hour')
             # 获取进度
             response = requests.get(
                 '{base_url}/query'.format(base_url=base_url),


### PR DESCRIPTION
## Summary
- Fix `urls_to_process[0]` IndexError in `downmodels.py` exception handler — moved initialization before try block and added empty list guard to prevent crash when download fails before URLs are populated
- Fix infinite polling loop in `_doubao.py` — added 1-hour timeout counter to prevent indefinite hang when Doubao ASR task never completes or API becomes unresponsive

## Test plan
- [ ] Verify model download error handling works when URLs list is empty
- [ ] Verify Doubao ASR times out gracefully instead of hanging forever

🤖 Generated with [Claude Code](https://claude.com/claude-code)