### PR TITLE
Fix _recognapi.py TypeError on missing Content-Type header

### DIFF
--- a/videotrans/recognition/_recognapi.py
+++ b/videotrans/recognition/_recognapi.py
@@ -75,7 +75,7 @@ class APIRecogn(BaseRecogn):
 
         res = requests.post(f"{self.api_url}", data={"language": self.detect_language}, files=files, timeout=600)
         res.raise_for_status()
-        content_type = res.headers.get('Content-Type')
+        content_type = res.headers.get('Content-Type', '')
         if 'application/json' in content_type:
             res = res.json()
             if "code" not in res or res['code'] != 0:


### PR DESCRIPTION
## Summary
- Fix TypeError in `_recognapi.py`: `res.headers.get('Content-Type')` returns `None` when the response lacks a Content-Type header, causing `'application/json' in None` to crash with TypeError. Added default empty string fallback.

## Test plan
- [ ] Verify recognition API calls don't crash when server returns response without Content-Type header

🤖 Generated with [Claude Code](https://claude.com/claude-code)