### PR TITLE
Fix fn_peiyin pitch copy-paste bug (2 more instances) and set_ass JSON crash

### DIFF
--- a/videotrans/component/set_ass.py
+++ b/videotrans/component/set_ass.py
@@ -515,8 +515,11 @@ class ASSStyleDialog(QDialog):
         self.blockSignals(True)
         try:
             if Path(JSON_FILE).exists():
-                with open(JSON_FILE, 'r') as f:
-                    style = json.load(f)
+                try:
+                    with open(JSON_FILE, 'r') as f:
+                        style = json.load(f)
+                except (json.JSONDecodeError, OSError):
+                    style = DEFAULT_STYLE
             else:
                 style = DEFAULT_STYLE
 

--- a/videotrans/winform/fn_peiyin.py
+++ b/videotrans/winform/fn_peiyin.py
@@ -269,7 +269,7 @@ def openwin():
         volume = int(winobj.volume_rate.value())
         volume = f'+{volume}%' if volume >= 0 else f'{volume}%'
         pitch = int(winobj.pitch_rate.value())
-        pitch = f'+{pitch}Hz' if pitch >= 0 else f'{volume}Hz'
+        pitch = f'+{pitch}Hz' if pitch >= 0 else f'{pitch}Hz'
 
         voice_file = f"{voice_dir}/{tts_type}-{lang}-{lujing_role}-{volume}-{pitch}.wav"
 
@@ -345,7 +345,7 @@ def openwin():
         volume = int(winobj.volume_rate.value())
         pitch = int(winobj.pitch_rate.value())
         volume = f'+{volume}%' if volume >= 0 else f'{volume}%'
-        pitch = f'+{pitch}Hz' if pitch >= 0 else f'{volume}Hz'
+        pitch = f'+{pitch}Hz' if pitch >= 0 else f'{pitch}Hz'
 
         if len(winobj.hecheng_importbtn.filelist) < 1 and not txt:
             return tools.show_error(


### PR DESCRIPTION
## Summary
- Fix 2 more instances of the pitch/volume copy-paste bug in `fn_peiyin.py` (lines 272, 348) where `f'{volume}Hz'` should be `f'{pitch}Hz'` for negative pitch values
- Add JSON parse error handling in `set_ass.py` `load_settings()` to fall back to `DEFAULT_STYLE` when the settings file is corrupted

This is the 4th PR fixing the same systemic copy-paste pattern (previous: #1057, #1060, #1073). The pitch variable was incorrectly replaced by volume in the negative branch of the ternary expression.

## Test plan
- [ ] Set a negative pitch value in the TTS synthesis dialog and verify the Hz value uses pitch (not volume)
- [ ] Corrupt the subtitle style JSON file and verify the app falls back to defaults instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)