### PR TITLE
Fix MiniMax translator bare raise crash

### DIFF
--- a/videotrans/translator/_minimax.py
+++ b/videotrans/translator/_minimax.py
@@ -71,7 +71,7 @@ class MiniMax(BaseTrans):
             result = response.choices[0].message.content.strip()
         else:
             logger.warning(f'[minimax]请求失败:{response=}')
-            raise# RuntimeError(f"[MiniMax] {response.choices[0].finish_reason}:{response}")
+            raise RuntimeError(f"[MiniMax] {response.choices[0].finish_reason}:{response}")
 
         match = re.search(r'<TRANSLATE_TEXT>(.*?)</TRANSLATE_TEXT>', result, re.S)
         if match:


### PR DESCRIPTION
## Summary
- Fix `raise# RuntimeError(...)` in `_minimax.py` where a `#` accidentally commented out the RuntimeError constructor, making it a bare `raise`
- When MiniMax API returns no content (empty `message.content`), this would crash with `RuntimeError: No active exception to re-raise` instead of showing the actual error reason

## Test plan
- [ ] Configure MiniMax as translation provider with invalid/expired API key
- [ ] Verify the error message shows the actual finish_reason and response instead of a confusing RuntimeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)