### PR TITLE
Fix Gemini TTS file handle leak in save_binary_file

### DIFF
--- a/videotrans/tts/_geminitts.py
+++ b/videotrans/tts/_geminitts.py
@@ -127,9 +127,8 @@ class GEMINITTS(BaseTTS):
             return {"bits_per_sample": bits_per_sample, "rate": rate}
 
         def save_binary_file(file_name, data):
-            f = open(file_name, "wb")
-            f.write(data)
-            f.close()
+            with open(file_name, "wb") as f:
+                f.write(data)
 
         client = genai.Client(
             api_key=params.get('gemini_key', ''),


### PR DESCRIPTION
## Summary
- Fix `save_binary_file()` in `_geminitts.py` to use `with` context manager instead of manual `open()/write()/close()`
- If `write()` raises an exception, the old code would leak the file handle

## Test plan
- [ ] Test Gemini TTS synthesis with valid API key
- [ ] Verify the output audio file is written correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)