### PR TITLE
Fix GLM ASR file handle leak and missing exit check

### DIFF
--- a/videotrans/recognition/_glmasr.py
+++ b/videotrans/recognition/_glmasr.py
@@ -27,40 +27,43 @@ class GLMASRRecogn(BaseRecogn):
         err=''
         ok_nums=0
         for i, it in enumerate(raws):
-            files = { "file": (Path(it['file']).name, open(it['file'], "rb")) }
-            payload = {
-                "model": "glm-asr-2512",
-                "stream": "false"
-            }
-            headers = {"Authorization": f"Bearer {apikey}"}
-            retry=0
-            while 1:
-                if retry>=RETRY_NUMS:
-                    it['text']=''
-                    break
-                response = requests.post(url, data=payload, files=files, headers=headers)
-                retry+=1
-                if response.status_code==200:                    
-                    it['text']=response.json()['text'].strip()
-                    ok_nums+=1
-                    self._signal(text=f"{i+1}/{len(raws)}")
-                    self._signal(
-                        text=f'{it["text"]}\n',
-                        type='subtitle'
-                    )
-                    break
-                
-                try:
-                    err_json=response.json()
-                except:
-                    raise RuntimeError(response.text)
-                else:
-                    logger.error(err_json)
-                    code=str(err_json['error']['code'])
-                    if code in ["1302","1303","1214"]:
-                        time.sleep(5)
-                        continue
-                    raise RuntimeError(err_json['error']['message'])                    
+            with open(it['file'], "rb") as f:
+                files = {"file": (Path(it['file']).name, f)}
+                payload = {
+                    "model": "glm-asr-2512",
+                    "stream": "false"
+                }
+                headers = {"Authorization": f"Bearer {apikey}"}
+                retry=0
+                while 1:
+                    if self._exit():
+                        return
+                    if retry>=RETRY_NUMS:
+                        it['text']=''
+                        break
+                    response = requests.post(url, data=payload, files=files, headers=headers)
+                    retry+=1
+                    if response.status_code==200:
+                        it['text']=response.json()['text'].strip()
+                        ok_nums+=1
+                        self._signal(text=f"{i+1}/{len(raws)}")
+                        self._signal(
+                            text=f'{it["text"]}\n',
+                            type='subtitle'
+                        )
+                        break
+
+                    try:
+                        err_json=response.json()
+                    except:
+                        raise RuntimeError(response.text)
+                    else:
+                        logger.error(err_json)
+                        code=str(err_json['error']['code'])
+                        if code in ["1302","1303","1214"]:
+                            time.sleep(5)
+                            continue
+                        raise RuntimeError(err_json['error']['message'])
 
         if ok_nums<1:
             raise RuntimeError(err)


### PR DESCRIPTION
## Summary
- Fix file handle leak: wrap `open()` in `with` context manager so the file is properly closed after the API request
- Add `self._exit()` check in the `while 1` retry loop so that user cancellation actually stops the recognition task instead of hanging

Same pattern as PR #1038 (which fixed the same issue in `_speech2text.py`).

## Test plan
- [ ] Use GLM ASR recognition with a valid ZhipuAI API key
- [ ] Cancel the recognition task mid-way and verify it stops promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)