### PR TITLE
修复：崩溃防护 — 3 处空数据/类型守卫防止运行时崩溃

### DIFF
--- a/videotrans/configure/base.py
+++ b/videotrans/configure/base.py
@@ -114,6 +114,7 @@ class BaseCon:
                 tools.remove_silence_wav(output_wav_file_path)
         except Exception as e:
             logger.exception(f'转为 48k wav时失败，跳过{e}',exc_info=True)
+            return False
         return True
 
 

--- a/videotrans/tts/_gptsovits.py
+++ b/videotrans/tts/_gptsovits.py
@@ -23,7 +23,7 @@ class GPTSoVITS(BaseTTS):
         if len(self.api_url)<10:
             raise StopTask(f'API URL is error: {self.api_url}')
         self.speed = self.get_speed()
-        self.roledict = tools.get_gptsovits_role()
+        self.roledict = tools.get_gptsovits_role() or {}
 
     @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO), after=after_log(logger, logging.INFO))
     def _run(self, data_item: Union[Dict, List, None], idx: int = -1) -> Union[str, None]:

--- a/videotrans/winform/chatterbox.py
+++ b/videotrans/winform/chatterbox.py
@@ -19,10 +19,16 @@ def openwin():
         if not url.startswith('http'):
             url = 'http://' + url
         params["chatterbox_url"] = url
-        params["chatterbox_cfg_weight"] = min(max(float(winobj.cfg_weight.text()), 0.0), 1.0)
-        params["chatterbox_exaggeration"] = min(max(float(winobj.exaggeration.text()), 0.25), 2.0)
+        try:
+            params["chatterbox_cfg_weight"] = min(max(float(winobj.cfg_weight.text()), 0.0), 1.0)
+        except (ValueError, TypeError):
+            return tools.show_error("cfg_weight must be a number")
+        try:
+            params["chatterbox_exaggeration"] = min(max(float(winobj.exaggeration.text()), 0.25), 2.0)
+        except (ValueError, TypeError):
+            return tools.show_error("exaggeration must be a number")
         params.save()
-        
+
         _rolename = next(reversed(tools.get_f5tts_role().values()))
         if not isinstance(_rolename,dict):
             return tools.show_error(tr("No reference audio {} exists",_rolename))
@@ -53,8 +59,14 @@ def openwin():
 
         params["chatterbox_url"] = url
 
-        params["chatterbox_cfg_weight"] = min(max(float(winobj.cfg_weight.text()), 0.0), 1.0)
-        params["chatterbox_exaggeration"] = min(max(float(winobj.exaggeration.text()), 0.25), 2.0)
+        try:
+            params["chatterbox_cfg_weight"] = min(max(float(winobj.cfg_weight.text()), 0.0), 1.0)
+        except (ValueError, TypeError):
+            return tools.show_error("cfg_weight must be a number")
+        try:
+            params["chatterbox_exaggeration"] = min(max(float(winobj.exaggeration.text()), 0.25), 2.0)
+        except (ValueError, TypeError):
+            return tools.show_error("exaggeration must be a number")
 
         params.save()
         tools.set_process(text='', type="refreshtts")


### PR DESCRIPTION
## 修复内容

对上游最新代码（2026-05-23）中仍存在的 3 处崩溃风险进行修复：

### 1. chatterbox.py — float() 输入验证
`cfg_weight` 和 `exaggeration` 字段直接 `float()` 转换，非数字输入导致 `ValueError` 崩溃。
添加 `try/except (ValueError, TypeError)` + 用户友好错误提示。

### 2. configure/base.py — convert_to_wav 失败静默返回 True
`convert_to_wav()` 异常时仍返回 `True`，调用方误认为转换成功继续执行。
改为异常时返回 `False`。

### 3. tts/_gptsovits.py — roledict None 守卫
`get_gptsovits_role()` 在未配置角色时返回 `None`（help_role.py:387），
但 `_gptsovits.py` 直接调用 `.keys()` 导致 `AttributeError`。
添加 `or {}` 默认值。

## 测试

已有 41 个测试全部通过（1 个上游已有的 test_get_pitch 失败与本次修改无关）。

## 说明

之前提交的 50 个 PR 中，绝大多数崩溃防护、资源泄漏、逻辑 bug 已被上游自行修复。
本轮仅针对上游最新代码中**仍存在**的问题提交补丁，保持最小改动。