### PR TITLE
修复：3 处 bare except 具体化，防止静默吞噬系统异常

### DIFF
--- a/videotrans/recognition/_glmasr.py
+++ b/videotrans/recognition/_glmasr.py
@@ -52,7 +52,7 @@ class GLMASRRecogn(BaseRecogn):
                 
                 try:
                     err_json=response.json()
-                except:
+                except (ValueError, KeyError):
                     raise SpeechToTextError(response.text)
                 else:
                     logger.error(err_json)

--- a/videotrans/recognition/_whispernet.py
+++ b/videotrans/recognition/_whispernet.py
@@ -253,7 +253,7 @@ class WhisperNetRecogn(BaseRecogn):
             try:
                 from Whisper.net import OnSegmentEventHandler
                 handler = OnSegmentEventHandler(on_segment)
-            except:
+            except (ImportError, AttributeError):
                 from System import Action
                 from Whisper.net import SegmentData
                 handler = Action[SegmentData](on_segment)

--- a/videotrans/tts/_piper.py
+++ b/videotrans/tts/_piper.py
@@ -76,7 +76,7 @@ class PiperTTS(BaseTTS):
             del _model_obj
             import gc
             gc.collect()
-        except:
+        except Exception:
             pass
 
         if ok==0:


### PR DESCRIPTION
## 修复内容

对上游最新代码中仍存在的 3 处 bare `except:` 进行具体化：

### 1. tts/_piper.py — gc.collect() 异常处理
`except: pass` 改为 `except Exception: pass`，
避免意外捕获 `KeyboardInterrupt` / `SystemExit` 导致程序无法终止。

### 2. recognition/_whispernet.py — Whisper.net API 版本兼容
`except:` 改为 `except (ImportError, AttributeError):`，
明确捕获 API 版本差异导致的导入/属性失败。

### 3. recognition/_glmasr.py — JSON 解析失败
`except:` 改为 `except (ValueError, KeyError):`，
明确捕获 JSON 解析异常，而非所有异常类型。

## 测试

已有 41 个测试全部通过。

## 说明

仅修改 3 行，每个改动将 bare `except` 替换为具体的异常类型，不影响正常逻辑。