### PR TITLE
feat(minimax): upgrade default model to MiniMax-M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ uv add nvidia-cublas-cu12 nvidia-cudnn-cu12
 | | WhisperX / Parakeet | Supports timestamp alignment & speaker diarization |
 | | Alibaba Qwen3-ASR / ByteDance Volcano | Online API, excellent for Chinese |
 | **Translation (LLM/MT)** | **DeepSeek** / ChatGPT | Supports context understanding, more natural translation |
-| | MiniMax AI | MiniMax M2.7 LLM, latest flagship model, OpenAI-compatible |
+| | MiniMax AI | MiniMax M3 LLM, latest flagship model, OpenAI-compatible |
 | | Google / Microsoft | Traditional machine translation, fast speed |
 | | Ollama / M2M100 | Fully local offline translation |
 | **TTS (Speech Synthesis)** | **Edge-TTS** | Microsoft free interface, natural effect |

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -138,7 +138,7 @@ uv add nvidia-cublas-cu12 nvidia-cudnn-cu12
 | | WhisperX / Parakeet | 支持时间轴对齐与说话人分离 |
 | | 阿里 Qwen3-ASR / 字节火山 | 在线 API，中文效果极佳 |
 | **翻译 (LLM/MT)** | **DeepSeek** / ChatGPT | 支持上下文理解，翻译更自然 |
-| | MiniMax AI | MiniMax M2.7 大模型，最新旗舰模型，OpenAI兼容接口 |
+| | MiniMax AI | MiniMax M3 大模型，最新旗舰模型，OpenAI兼容接口 |
 | | Google / Microsoft | 传统机器翻译，速度快 |
 | | Ollama / M2M100 | 完全本地离线翻译 |
 | **语音合成 (TTS)** | **Edge-TTS** | 微软免费接口，效果自然 |

--- a/videotrans/configure/contants.py
+++ b/videotrans/configure/contants.py
@@ -165,7 +165,7 @@ Zijiehuoshan_Model="doubao-seed-2-0-pro-260215,doubao-seed-2-0-lite-260215,douba
 Whisper_Models="tiny,tiny.en,base,base.en,small,small.en,medium,medium.en,large-v3-turbo,large-v1,large-v2,large-v3,distil-large-v3,distil-large-v3.5"
 Openai_Whisper_Models="tiny,tiny.en,base,base.en,small,small.en,medium,medium.en,large-v3-turbo,large-v1,large-v2,large-v3"
 
-MINIMAX_MODELS="MiniMax-M2.7,MiniMax-M2.7-highspeed,MiniMax-M2.5,MiniMax-M2.5-highspeed"
+MINIMAX_MODELS="MiniMax-M3,MiniMax-M2.7,MiniMax-M2.7-highspeed"
 MINIMAX_TTS_MODELS="speech-2.8-hd,speech-2.8-turbo,speech-2.6-hd,speech-2.6-turbo,speech-02-hd,speech-02-turbo"
 
 

--- a/videotrans/translator/_minimax.py
+++ b/videotrans/translator/_minimax.py
@@ -10,7 +10,7 @@ class MiniMax(OpenAICampat):
         self.ainame ="minimax"
         self.api_key = params.get('minimax_key', '')
         self.max_tokens =int(params.get('minimax_max_tokens',8192))
-        self.model_name =params.get('minimax_model', 'MiniMax-M2.7')
+        self.model_name =params.get('minimax_model', 'MiniMax-M3')
         api_url = params.get('minimax_api', 'api.minimax.io')
         if not api_url.startswith('https'):
             api_url = 'https://' +api_url


### PR DESCRIPTION
## What

Bumps the bundled MiniMax (minimax) translator provider to use **MiniMax-M3** — the new flagship — as the default model.

## Changes

- `videotrans/configure/contants.py` — `MINIMAX_MODELS` list reordered/cleaned:
  - Added `MiniMax-M3` at the head (so `MINIMAX_MODELS.split(',')[0]` in `config.py` picks it as default).
  - Kept `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as legacy options.
  - Removed superseded `MiniMax-M2.5` / `MiniMax-M2.5-highspeed`.
- `videotrans/translator/_minimax.py` — fallback default in the `MiniMax` translator class also bumped from `MiniMax-M2.7` to `MiniMax-M3`.
- `README.md` / `docs/README_CN.md` — flagship model description updated to M3.

## What is NOT changed

- TTS models (`speech-2.x` / `MINIMAX_TTS_MODELS`) untouched.
- API endpoint `api.minimax.io` and `minimax_api` config untouched.
- `Openrouter_Model` and `Guiji_Model` (third-party gateway listings) intentionally left as-is — they reference minimax via different upstream namespaces.

## Notes for users

Existing users with a saved `minimax_model` value continue to use whatever they had selected; only fresh installs / users who never overrode the default will pick up M3 automatically.