### PR TITLE
Bug fix: 修复 CosyVoice3 提示词和试听声道兼容

### DIFF
--- a/videotrans/tts/_cosyvoice.py
+++ b/videotrans/tts/_cosyvoice.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 from typing import Union, Dict, List
+from pathlib import Path
+import wave
 
 from gradio_client import handle_file
 from videotrans.configure.config import params
@@ -16,10 +18,14 @@ class CosyVoice(GradioBase):
 
     def _run(self, data_item: Union[Dict, List, None], idx: int = -1)->Union[str, None]:
         ref_wav,prompt_text = self.get_ref_wav(data_item)
-        # 参考音频对应文本内容
-        # 提示词，克隆时放入参考音频文本中
-        #instruct_text = params.get('cosyvoice_instruct_text', '')
-        prompt_text = f'You are a helpful assistant.<|endofprompt|>{prompt_text}'
+        if not ref_wav or not Path(ref_wav).exists() or Path(ref_wav).stat().st_size == 0:
+            raise RuntimeError(f"CosyVoice reference audio is empty or missing: {ref_wav}")
+        with wave.open(ref_wav, "rb") as wav_file:
+            if wav_file.getnframes() == 0:
+                raise RuntimeError(f"CosyVoice reference audio has no frames: {ref_wav}")
+        prompt_text = (prompt_text or "").strip()
+        if "<|endofprompt|>" not in prompt_text:
+            prompt_text = f"You are a helpful assistant.<|endofprompt|>{prompt_text}"
         kwargs = {
             "tts_text": data_item.get('text', '').strip(),
             "mode_checkbox_group": "3s极速复刻",
@@ -34,4 +40,3 @@ class CosyVoice(GradioBase):
 
         }
         return self._send(kwargs, data_item)
-

--- a/videotrans/util/help_misc.py
+++ b/videotrans/util/help_misc.py
@@ -322,6 +322,17 @@ def pygameaudio(filepath=None):
         import soundfile as sf
         import sounddevice as sd
         data, fs = sf.read(filepath)
+        channels = 1 if data.ndim == 1 else data.shape[1]
+        try:
+            device_info = sd.query_devices(kind='output')
+            max_channels = int(device_info.get('max_output_channels') or channels)
+        except Exception:
+            max_channels = channels
+
+        if channels == 1 and max_channels >= 2:
+            data = data.reshape(-1, 1).repeat(2, axis=1)
+        elif channels > max_channels > 0:
+            data = data[:, :max_channels]
         sd.play(data, fs)
         sd.wait()
     except Exception as e:
@@ -478,4 +489,3 @@ def get_tanslate_type(type_index=None):
 
 def get_tts_type(type_index=None):
     return _get_type_name(type_index, TTS_NAME_LIST)
-


### PR DESCRIPTION
本次修复两个实际使用中遇到的问题，分别发生在 CosyVoice3 复刻配音和本地试听播放流程。

  问题一：CosyVoice3 zero-shot 复刻时报错

  使用 pyvideotrans 调用本地 CosyVoice3 WebUI 的 `3s极速复刻` 模式时，如果参考音频对应的 `prompt_text` 为空，或者没有包含 CosyVoice3 要求的 `<|endofprompt|>` 标记，CosyVoice3 会在推理阶段抛出断言错误：

  ```text
  AssertionError: <|endofprompt|> not detected in CosyVoice3 text or prompt_text, check your input!

  随后由于 LLM token 生成失败，后续 hifigan 流程还可能继续触发类似错误：

  RuntimeError: Calculated padded input size per channel: (3). Kernel size: (4). Kernel size can't be greater than actual input size

  原逻辑会无条件给 prompt_text 添加：

  You are a helpful assistant.<|endofprompt|>

  但如果用户已经在角色配置中手动填写了包含 <|endofprompt|> 的 prompt，会造成重复追加。现在改为先清理空值，再判断是否已包含 <|endofprompt|>；如果没有才自动补充默认前缀。

  这样既兼容 CosyVoice3 的必要输入格式，也避免重复添加特殊标记。

  问题二：试听声音时输出设备声道不兼容

  在本地点击试听声音时，部分音频设备报告的最大输出声道数与音频文件声道数不一致。例如默认输出设备只支持单声道，但传入了双声道音频，会导致 sounddevice 打开输出流失败：

  sounddevice.PortAudioError: Error opening OutputStream: Invalid number of channels [PaErrorCode -9998]

  原逻辑直接执行：

  sd.play(data, fs)

  没有根据默认输出设备能力调整音频声道。

  现在播放前会查询默认输出设备的 max_output_channels，并根据设备能力处理音频数据：

  - 单声道音频在双声道设备上复制为双声道。
  - 多声道音频在低声道设备上裁剪到设备支持的声道数。
  - 查询设备失败时保持原逻辑兜底。

  这样可以避免试听播放因为声道数不匹配失败。

