### PR TITLE
Fix: Multi-Role Dubbing per-row voice assignments are silently ignored (SrtItem.get signature)

### DIFF
--- a/videotrans/task/taskcfg.py
+++ b/videotrans/task/taskcfg.py
@@ -74,8 +74,8 @@ class SrtItem:
     def __setitem__(self, key, value):
         return setattr(self, key, value)
 
-    def get(self, key):
-        return getattr(self,key)
+    def get(self, key, default=None):
+        return getattr(self, key, default)
 
     def items(self):
         _names=("line","time","start_time","end_time","startraw","endraw","text","spk","filename")


### PR DESCRIPTION
### Summary

Multi-Role Dubbing dialog ("Assign voice per sub") lets users assign a voice
per subtitle row, but the assigned voices are silently ignored at runtime —
every row uses the Default Role instead.

### Root Cause

`SrtItem.get` in `videotrans/task/taskcfg.py` was defined with one positional
parameter and no default:

```python
def get(self, key):
    return getattr(self, key)
```

In `videotrans/task/dubbing.py:177`, `_tts()` reads the per-row override via:

```python
spec_role = app_cfg.dubbing_role.get(int(it.get('line', 1))) \
            if self.is_multi_role else None
```

`it.get('line', 1)` therefore raises
`TypeError: SrtItem.get() takes 2 positional arguments but 3 were given`,
which is swallowed by the surrounding `try/except Exception`. As a result
`spec_role` is always `None` and `voice_role` falls back to
`self.cfg.voice_role` (the Default Role) for every subtitle.

The same call pattern is used elsewhere (`process/tts_fun.py:83`,
`process/stt_fun.py:489/493`, `recognition/_ai302.py:141`,
`recognition/_zijiemodel.py:78`, `tts/_piper.py:43`), where it would also
break if the iterated item happened to be a `SrtItem`.

### Fix

Align `SrtItem.get` with `dict.get` semantics by accepting a default arg:

```python
def get(self, key, default=None):
    return getattr(self, key, default)
```

### Verification

- Standalone repro reproduces the original `TypeError` and confirms it is
  silently caught.
- After the fix, `app_cfg.dubbing_role.get(int(it.get('line', 1)))` returns
  the assigned role for the matching line, so `voice_role` is the assigned
  voice rather than the default.
- I patched the `videotrans.task.taskcfg` entry inside the v4.01 sp.exe's
  PYZ in-place (without rebuilding) and confirmed the bytecode loads
  cleanly at startup.
