### PR TITLE
fix(tts): OmniVoice Studio channel — REST integration replacing the broken Gradio client

### DIFF
--- a/videotrans/tts/_omnivoice.py
+++ b/videotrans/tts/_omnivoice.py
@@ -2,19 +2,36 @@ import logging
 from dataclasses import dataclass
 from typing import Union, Dict, List
 
-from gradio_client import handle_file
+import requests
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type, before_log, after_log
 
-from videotrans.configure.config import settings, logger
-from videotrans.configure.excepts import NO_RETRY_EXCEPT
-from videotrans.tts._gradio import GradioBase
+from videotrans.configure.config import params, settings, logger
+from videotrans.configure.excepts import NO_RETRY_EXCEPT, StopTask
+from videotrans.tts._base import BaseTTS
+
 
 @dataclass
-class OmniVoice(GradioBase):
+class OmniVoice(BaseTTS):
+    """OmniVoice Studio TTS/clone channel (REST).
+
+    OmniVoice Studio (https://github.com/debpalash/OmniVoice-Studio) is a
+    FastAPI desktop app — its default API listens on http://127.0.0.1:3900.
+    This channel POSTs ``/generate`` per subtitle line (multipart): the line
+    text plus the per-line reference wav + transcript for voice cloning, and
+    receives WAV bytes back. Replaces the previous gradio_client integration,
+    which targeted a ``/_clone_fn`` Gradio endpoint that current OmniVoice
+    Studio builds do not expose (the app is FastAPI-only).
+
+    OmniVoice Studio pins this request shape with a contract test on their
+    side (tests/test_pyvideotrans_contract.py), so the surface used here is
+    guaranteed by their CI.
+    """
+
     def __post_init__(self):
-        self.ainame="omnivoice"
-        # 语言代码 对应语言名称
-        lang_code={
+        self.ainame = "omnivoice"
+        # ISO code -> natural-language name (OmniVoice accepts language
+        # names; "Auto" lets it detect from text).
+        lang_code = {
             "en": "English",
             "zh": "Chinese",
             "zh-cn": "Chinese",
@@ -49,29 +66,53 @@ class OmniVoice(GradioBase):
             "fa": "Persian",
             "fil": "Filipino",
             "ur": "Urdu",
-            "yue": "Cantonese"
+            "yue": "Cantonese",
         }
-        self.lang=lang_code.get(self.language,'Auto') if self.language else 'Auto'
+        self.lang = lang_code.get(self.language, 'Auto') if self.language else 'Auto'
         super().__post_init__()
-
+        self.api_url = (params.get('omnivoice_url', '') or 'http://127.0.0.1:3900').strip().rstrip('/')
+        if not self.api_url.startswith('http'):
+            self.api_url = 'http://' + self.api_url
+        if len(self.api_url) < 10:
+            raise StopTask(f'OmniVoice API URL is error: {self.api_url}')
 
     @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO), after=after_log(logger, logging.INFO))
     def _run(self, data_item: Union[Dict, List, None], idx: int = -1) -> Union[str, None]:
+        ref_wav, ref_text = self.get_ref_wav(data_item)
 
-        ref_wav,ref_text = self.get_ref_wav(data_item)
-        kwargs = {
-            "text":data_item.get('text',''),
-            "lang":self.lang,
-            "ref_aud":handle_file(ref_wav),
-            "ref_text":ref_text,
-            "instruct":'',
-            "ns":32,
-            "gs":2.0,
-            "dn":False,
-            "sp":self.get_speed(),
-            "du":0,
-            "pp":True,
-            "po":False,
-            "api_name":"/_clone_fn",
+        data = {
+            "text": data_item.get('text', ''),
+            "language": self.lang,
+            "num_step": 32,
+            "guidance_scale": 2.0,
+            "speed": self.get_speed(),
+            "denoise": "false",
+            "postprocess_output": "true",
         }
-        return self._send(kwargs, data_item)
+        files = None
+        if ref_wav:
+            files = {"ref_audio": open(ref_wav, 'rb')}
+            if ref_text:
+                data["ref_text"] = ref_text
+
+        logger.debug(f'OmniVoice request: {self.api_url=}/generate {data=}')
+        try:
+            response = requests.post(
+                f"{self.api_url}/generate",
+                data=data,
+                files=files,
+                timeout=3600,
+                proxies={"https": "", "http": ""},
+            )
+        finally:
+            if files:
+                files["ref_audio"].close()
+
+        if not response.ok:
+            error_data = response.text + f"\n{self.api_url=}"
+            logger.error(f'OmniVoice returned error: {error_data=}')
+            return error_data
+
+        with open(data_item['filename'] + ".wav", 'wb') as f:
+            f.write(response.content)
+        self.convert_to_wav(data_item['filename'] + ".wav", data_item['filename'])


### PR DESCRIPTION
Hi! I maintain [OmniVoice Studio](https://github.com/debpalash/OmniVoice-Studio) — thank you for integrating it as a TTS/clone channel. This PR fixes the channel, which is currently broken for all users (see #1124).

## Problem

Current OmniVoice Studio builds are a FastAPI app (default `http://127.0.0.1:3900`) and expose **no Gradio app** — the `gradio_client` call to `api_name="/_clone_fn"` fails while fetching the Gradio config (`Could not fetch config`), which lands in the fatal stop-task branch, so every dub using this channel hard-stops at the first line.

## Fix

Rewrite the channel as a plain REST integration (mirroring the GPT-SoVITS channel's conventions):

- `POST {omnivoice_url}/generate` per subtitle line, multipart: `text`, `language` (same natural-language name map as before, `Auto` default), per-line `ref_audio` + `ref_text` from `get_ref_wav()` for cloning, `speed`, and the generation knobs (`num_step=32`, `guidance_scale=2.0`) the old call already used.
- Response is WAV bytes → written and converted via `convert_to_wav`, like the other REST channels.
- The existing `omnivoice_url` setting keeps working; it now defaults to the app's standard `http://127.0.0.1:3900` when unset.
- Lines without a usable reference fall back to OmniVoice's default voice instead of erroring.

## Stability guarantee from our side

We've added a contract test in OmniVoice Studio's CI ([tests/test_pyvideotrans_contract.py](https://github.com/debpalash/OmniVoice-Studio/pull/359)) that pins exactly the request/response shape this channel uses — params, the `Auto` language sentinel, `audio/wav` response. If we ever change `/generate` in a way that would break this channel, **our** CI fails. The bridge shouldn't silently break again.

Happy to adjust anything to fit your conventions — and thanks again for the integration. Fixes #1124.