### PR TITLE
Fix FunASR crash when hotwords is empty

### DIFF
--- a/videotrans/codes/model.py
+++ b/videotrans/codes/model.py
@@ -555,7 +555,13 @@ class FunASRNano(nn.Module):
         frontend=None,
         **kwargs,
     ):
-        hotwords = kwargs.get("hotwords", [])
+        hotwords = kwargs.get("hotwords") or []
+        if isinstance(hotwords, str):
+            hotwords = [
+                word.strip()
+                for word in hotwords.replace("，", ",").split(",")
+                if word.strip()
+            ]
         if len(hotwords) > 0:
             hotwords = ", ".join(hotwords)
             prompt = f"请结合上下文信息，更加准确地完成语音转写任务。如果没有相关信息，我们会留空。\n\n\n**上下文信息：**\n\n\n"


### PR DESCRIPTION
## Summary

This PR fixes a crash in the Fun-ASR-Nano prompt preparation path when the optional `hotwords` inference parameter is explicitly passed as `None`.

`hotwords` is an optional FunASR inference parameter. When no hotwords are configured, callers may omit it, pass an empty list, pass an empty string, or pass `None`. The current implementation handles a missing key and an empty list, but not an explicit `None`, causing `len(None)` to crash before transcription starts.

## Problem

The current code reads `hotwords` with a default empty list:

```python
hotwords = kwargs.get("hotwords", [])
if len(hotwords) > 0:
```

This only falls back to `[]` when the key is missing. If upstream code passes:

```python
{"hotwords": None}
```

then `kwargs.get("hotwords", [])` returns `None`, and `len(hotwords)` raises:

```text
TypeError: object of type 'NoneType' has no len()
```

This can happen in the local FunASR recognition workflow when no hotwords are configured.

## Changes

Normalize `hotwords` before checking its length:

- Treat `None` and empty values as no hotwords.
- Preserve existing list-based hotword behavior.
- Support comma-separated string hotwords, including Chinese comma separators.

Examples now handled safely:

```python
hotwords=None
hotwords=""
hotwords=[]
hotwords=["keyword1", "keyword2"]
hotwords="keyword1, keyword2"
hotwords="keyword1?keyword2"
```

## Why This Is Safe

FunASR hotwords are optional. If no hotwords are provided, recognition should continue without adding a hotword prompt. This change only normalizes the optional value before prompt construction and does not change model loading or transcription logic.

## Testing

- Ran syntax check:

```bash
python -m py_compile videotrans/codes/model.py
```

## Related Error

```text
TypeError: object of type 'NoneType' has no len()

File "videotrans/codes/model.py", line 559, in inference
    if len(hotwords) > 0:
```
