### PR TITLE
Add TwelveLabs Pegasus video understanding (opt-in analyze task)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ uv sync
 
 > By default, `qwen-tts`, `qwen-asr`, `moss-tts`, and `chatterbox` are not installed locally.
 > - To install all optional channels: `uv sync --all-extra`
-> - To install individually: `uv sync --extra qwentts` / `uv sync --extra qwenasr` / `uv sync --extra mosstts` / `uv sync --extra chatterbox`
+> - To install individually: `uv sync --extra qwentts` / `uv sync --extra qwenasr` / `uv sync --extra mosstts` / `uv sync --extra chatterbox` / `uv sync --extra twelvelabs`
 
 ### 4. Launch Software
 
@@ -155,6 +155,7 @@ uv add nvidia-cublas-cu12 nvidia-cudnn-cu12
 | | **F5-TTS / CosyVoice** | Supports **Voice Cloning**, requires local deployment |
 | | GPT-SoVITS / ChatTTS | High-quality open-source TTS |
 | | 302.AI / OpenAI / Azure | High-quality commercial API |
+| **Video Understanding** | **TwelveLabs Pegasus** | Opt-in content-aware analysis: summarize / describe a video before translating. `cli.py --task analyze`. [Free API key](https://twelvelabs.io) |
 
 ---
 

--- a/cli.py
+++ b/cli.py
@@ -37,6 +37,9 @@ TEXT_DB: Dict[str, Dict[str, str]] = {
     "exec_tts_task": {"zh": "[执行任务] 语音合成 (TTS)", "en": "[Task] Text-to-Speech (TTS)"},
     "exec_sts_task": {"zh": "[执行任务] 字幕翻译 (STS)", "en": "[Task] Subtitle Translation (STS)"},
     "exec_vtv_task": {"zh": "[执行任务] 视频翻译 (VTV)", "en": "[Task] Video Translation (VTV)"},
+    "exec_analyze_task": {"zh": "[执行任务] 视频内容理解 (TwelveLabs)", "en": "[Task] Video Understanding (TwelveLabs)"},
+    "analyze_result": {"zh": "[分析结果]\n{}", "en": "[Analysis]\n{}"},
+    "analyze_saved":  {"zh": "[已保存] {}", "en": "[Saved] {}"},
     "process_file":  {"zh": "[处理文件] {}", "en": "[File] {}"},
     "param_list":    {"zh": "[参数列表] {}", "en": "[Params] {}"},
     "output_dir":    {"zh": "[输出目录] {}", "en": "[Output Dir] {}"},
@@ -65,8 +68,8 @@ TEXT_DB: Dict[str, Dict[str, str]] = {
               "  %(prog)s --list languages"
     },
     "help_task": {
-        "zh": "任务类型: stt(语音转录), tts(文字配音), sts(字幕翻译), vtv(视频翻译)",
-        "en": "Task type: stt(Speech to Text), tts(Text to Speech), sts(Subtitle Trans), vtv(Video Trans)"
+        "zh": "任务类型: stt(语音转录), tts(文字配音), sts(字幕翻译), vtv(视频翻译), analyze(TwelveLabs 视频内容理解)",
+        "en": "Task type: stt(Speech to Text), tts(Text to Speech), sts(Subtitle Trans), vtv(Video Trans), analyze(TwelveLabs Video Understanding)"
     },
     "help_name": {
         "zh": "待处理文件的绝对路径 (请使用双引号包裹含空格的路径)",
@@ -133,10 +136,16 @@ TEXT_DB: Dict[str, Dict[str, str]] = {
     "help_clear_cache":    {"zh": "完成后清理缓存 (默认)", "en": "Clear cache after finish (default)"},
     "help_no_clear_cache": {"zh": "不清理缓存", "en": "Do not clear cache"},
 
+    # --- analyze (TwelveLabs video understanding) ---
+    "group_analyze":   {"zh": "Analyze (TwelveLabs 视频内容理解) 参数", "en": "Analyze (TwelveLabs Video Understanding) Parameters"},
+    "help_tl_prompt":  {"zh": "发送给 Pegasus 的提示词 (默认为视频内容摘要)", "en": "Prompt sent to Pegasus (defaults to a content summary)"},
+    "help_tl_maxtoken":{"zh": "Pegasus 最大返回 token 数 (默认 2048)", "en": "Max Pegasus response tokens (default 2048)"},
+    "err_tl_key":      {"zh": "未配置 TwelveLabs 密钥,请设置 twelvelabs_key 或 TWELVELABS_API_KEY 环境变量,免费密钥: https://twelvelabs.io", "en": "TwelveLabs API key not set. Configure twelvelabs_key or the TWELVELABS_API_KEY env var. Free key: https://twelvelabs.io"},
+
     # --- Error messages ---
     "err_missing_task": {
-        "zh": "缺少 --task 参数,可选值: stt, tts, sts, vtv\n使用 --help 查看详细帮助",
-        "en": "Missing --task parameter. Choose: stt, tts, sts, vtv\nUse --help for details"
+        "zh": "缺少 --task 参数,可选值: stt, tts, sts, vtv, analyze\n使用 --help 查看详细帮助",
+        "en": "Missing --task parameter. Choose: stt, tts, sts, vtv, analyze\nUse --help for details"
     },
     "err_file_not_found": {
         "zh": "文件不存在: {}\n请检查路径是否正确,含空格的路径请用双引号包裹",
@@ -276,6 +285,32 @@ def vtv_fun(params: dict) -> None:
         raise
 
 
+def analyze_fun(args: argparse.Namespace) -> None:
+    """Run TwelveLabs Pegasus content understanding on a video file.
+
+    Opt-in and standalone: it does not touch the transcribe/translate/dub
+    pipeline. Writes the analysis next to the video as <name>.analyze.txt.
+    """
+    from videotrans.util import twelvelabs_analyze
+
+    print(f"\n{tr('exec_analyze_task')}")
+    print(tr('process_file', args.name))
+    try:
+        text = twelvelabs_analyze.analyze_video(
+            args.name,
+            prompt=args.tl_prompt or twelvelabs_analyze.DEFAULT_PROMPT,
+            max_tokens=args.tl_max_tokens,
+        )
+        print(tr('analyze_result', text))
+        out = Path(args.name).with_suffix('.analyze.txt')
+        out.write_text(text, encoding='utf-8')
+        print(tr('analyze_saved', str(out)))
+        print(tr('done'))
+    except Exception as e:
+        print(tr('failed', str(e)), file=sys.stderr)
+        raise
+
+
 # ---------------------------------------------------------------------------
 # List functions
 # ---------------------------------------------------------------------------
@@ -327,7 +362,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     parser.add_argument('--version', action='version', version='%(prog)s 4.03')
 
-    parser.add_argument('--task', type=str, choices=['stt', 'tts', 'sts', 'vtv'],
+    parser.add_argument('--task', type=str, choices=['stt', 'tts', 'sts', 'vtv', 'analyze'],
                         help=tr("help_task"))
     parser.add_argument('--name', type=str, help=tr("help_name"))
 
@@ -377,6 +412,11 @@ def build_parser() -> argparse.ArgumentParser:
     vtv_group.add_argument('--subtitle_type', type=int, default=1, help=tr("help_subtitle_type"))
     vtv_group.add_argument('--clear_cache', action='store_true', default=True, help=tr("help_clear_cache"))
     vtv_group.add_argument('--no-clear-cache', dest='clear_cache', action='store_false', help=tr("help_no_clear_cache"))
+
+    # --- Analyze (TwelveLabs) ---
+    analyze_group = parser.add_argument_group(tr("group_analyze"))
+    analyze_group.add_argument('--tl_prompt', type=str, default=None, help=tr("help_tl_prompt"))
+    analyze_group.add_argument('--tl_max_tokens', type=int, default=2048, help=tr("help_tl_maxtoken"))
 
     return parser
 
@@ -555,6 +595,17 @@ def main() -> int:
     # Set runtime flags
     app_cfg.exit_soft = False
     app_cfg.exec_mode = 'cli'
+
+    # TwelveLabs analyze is a standalone, opt-in task: it calls a remote
+    # video-understanding API and does not need the GPU / SRT / cache setup.
+    if args.task == 'analyze':
+        try:
+            analyze_fun(args)
+            return 0
+        except KeyboardInterrupt:
+            return 130
+        except Exception:
+            return 1
 
     # Get GPU info
     from videotrans.util.gpus import getset_gpu

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -57,6 +57,9 @@ uv run cli.py --task <任务类型> --name "<文件路径>" [其他参数]
 | `tts` | 文字配音 — 将 SRT 字幕或文本转为语音音频 | 预处理 → 配音 → 音画对齐 → 输出音频 |
 | `sts` | 字幕翻译 — 将 SRT 字幕翻译为目标语言 | 预处理 → 翻译 → 输出字幕 |
 | `vtv` | 视频翻译 — 全流程：识别 → 翻译 → 配音 → 合成视频 | 预处理 → 识别 → 说话人分离 → 翻译 → 配音 → 对齐 → 二次识别 → 合成视频 |
+| `analyze` | 视频内容理解（TwelveLabs Pegasus）— 生成视频内容摘要/描述 | 调用 TwelveLabs API → 输出文本 `.analyze.txt` |
+
+> `analyze` 为可选功能，需先安装 `uv sync --extra twelvelabs`，并配置 `twelvelabs_key`（或 `TWELVELABS_API_KEY` 环境变量）。免费密钥见 https://twelvelabs.io 。该任务独立运行，不影响转录/翻译/配音流程。
 
 ---
 
@@ -64,7 +67,7 @@ uv run cli.py --task <任务类型> --name "<文件路径>" [其他参数]
 
 | 选项 | 说明 | 默认值 |
 |------|------|--------|
-| `--task {stt,tts,sts,vtv}` | **必选** — 任务类型 | — |
+| `--task {stt,tts,sts,vtv,analyze}` | **必选** — 任务类型 | — |
 | `--name FILE` | **必选** — 输入文件的绝对路径 | — |
 | `--output-dir DIR` | 输出目录 | `<软件目录>/output/<文件名>/` |
 | `--list {providers,languages,models}` | 查询可用渠道/语言/模型列表 | — |
@@ -402,6 +405,38 @@ uv run cli.py --task vtv --name "60.mp4" --source_language_code zh-cn --target_l
 
 ```bash
 uv run cli.py --task vtv --name "60.mp4" --source_language_code zh-cn --target_language_code en --voice_role "en-US-GuyNeural" -v
+```
+
+---
+
+## analyze — 视频内容理解（TwelveLabs）
+
+使用 TwelveLabs **Pegasus** 视频理解模型，对视频内容进行理解并生成自然语言描述/摘要，可在翻译/配音之前快速了解视频讲了什么。结果保存为输入文件同目录下的 `<文件名>.analyze.txt`。
+
+### 准备
+
+```bash
+uv sync --extra twelvelabs            # 安装可选依赖
+export TWELVELABS_API_KEY=tlk_xxx     # 或在设置中配置 twelvelabs_key
+```
+
+> 免费密钥（含慷慨免费额度）：https://twelvelabs.io
+
+### 参数说明
+
+| 选项 | 说明 | 默认值 |
+|------|------|--------|
+| `--tl_prompt TEXT` | 发送给 Pegasus 的提示词 | 自动摘要提示 |
+| `--tl_max_tokens N` | 最大返回 token 数 | `2048` |
+
+### 示例
+
+```bash
+# 默认摘要
+uv run cli.py --task analyze --name "60.mp4"
+
+# 自定义提问
+uv run cli.py --task analyze --name "60.mp4" --tl_prompt "列出视频中出现的所有产品和品牌"
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -282,6 +282,9 @@ mosstts = [
 chatterbox=[
     "chatterbox-tts"
 ]
+twelvelabs = [
+    "twelvelabs>=1.2.8",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/test_twelvelabs_analyze.py
+++ b/tests/test_twelvelabs_analyze.py
@@ -1,0 +1,123 @@
+"""
+Tests for videotrans.util.twelvelabs_analyze — the opt-in TwelveLabs
+content-aware video understanding helper.
+
+The no-network tests mock the twelvelabs SDK so they run without the package
+installed or any API key. The live test is skipped unless TWELVELABS_API_KEY
+is set, mirroring how the project gates other network-dependent checks.
+
+Uses conftest.py mocks for heavy dependencies.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from videotrans.util import twelvelabs_analyze as tla
+
+
+# ===========================================================================
+# Module surface / constants
+# ===========================================================================
+def test_models_are_pinned():
+    assert tla.PEGASUS_MODEL == "pegasus1.5"
+    assert tla.MARENGO_MODEL == "marengo3.0"
+
+
+def test_default_prompt_is_nonempty():
+    assert isinstance(tla.DEFAULT_PROMPT, str) and tla.DEFAULT_PROMPT.strip()
+
+
+def test_cli_registers_analyze_task():
+    from cli import build_parser, analyze_fun  # noqa: F401
+
+    parser = build_parser()
+    args = parser.parse_args(["--task", "analyze", "--name", "x.mp4",
+                              "--tl_prompt", "hi", "--tl_max_tokens", "10"])
+    assert args.task == "analyze"
+    assert args.tl_prompt == "hi"
+    assert args.tl_max_tokens == 10
+
+
+# ===========================================================================
+# Key resolution
+# ===========================================================================
+def test_get_api_key_prefers_params(monkeypatch):
+    monkeypatch.setattr(tla.params, "get", lambda k, d="": "from_params" if k == "twelvelabs_key" else d)
+    assert tla._get_api_key() == "from_params"
+
+
+def test_get_api_key_falls_back_to_env(monkeypatch):
+    monkeypatch.setattr(tla.params, "get", lambda k, d="": d)
+    monkeypatch.setenv("TWELVELABS_API_KEY", "from_env")
+    assert tla._get_api_key() == "from_env"
+
+
+def test_missing_key_raises_clear_error(monkeypatch):
+    monkeypatch.setattr(tla.params, "get", lambda k, d="": d)
+    monkeypatch.delenv("TWELVELABS_API_KEY", raising=False)
+    # Pretend the SDK is installed so we reach the key check, not the import error.
+    with patch.dict(sys.modules, {"twelvelabs": MagicMock()}):
+        with pytest.raises(RuntimeError, match="API key"):
+            tla._make_client()
+
+
+# ===========================================================================
+# No-network wiring tests (SDK mocked)
+# ===========================================================================
+def test_analyze_video_wiring(monkeypatch, tmp_path):
+    monkeypatch.setattr(tla.params, "get", lambda k, d="": d)
+    monkeypatch.setenv("TWELVELABS_API_KEY", "k")
+
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake-bytes")
+
+    fake_client = MagicMock()
+    fake_client.analyze.return_value = MagicMock(data="A dog runs in a park.")
+
+    with patch.object(tla, "_make_client", return_value=fake_client):
+        # VideoContext_Base64String is imported inside the function from the SDK.
+        with patch.dict(sys.modules, {"twelvelabs.types": MagicMock()}):
+            out = tla.analyze_video(str(video), prompt="What happens?", max_tokens=128)
+
+    assert out == "A dog runs in a park."
+    _, kwargs = fake_client.analyze.call_args
+    assert kwargs["model_name"] == "pegasus1.5"
+    assert kwargs["prompt"] == "What happens?"
+    assert kwargs["max_tokens"] == 128
+
+
+def test_analyze_video_missing_file(monkeypatch):
+    monkeypatch.setenv("TWELVELABS_API_KEY", "k")
+    with pytest.raises(FileNotFoundError):
+        tla.analyze_video("/no/such/file.mp4")
+
+
+def test_embed_text_returns_vector(monkeypatch):
+    fake_seg = MagicMock(float_=[0.1] * 512)
+    fake_client = MagicMock()
+    fake_client.embed.create.return_value = MagicMock(
+        text_embedding=MagicMock(segments=[fake_seg])
+    )
+    with patch.object(tla, "_make_client", return_value=fake_client):
+        vec = tla.embed_text("a person walking a dog")
+    assert len(vec) == 512
+    _, kwargs = fake_client.embed.create.call_args
+    assert kwargs["model_name"] == "marengo3.0"
+    assert kwargs["text"] == "a person walking a dog"
+
+
+# ===========================================================================
+# Live test — only runs with a real key
+# ===========================================================================
+@pytest.mark.skipif(
+    not os.environ.get("TWELVELABS_API_KEY"),
+    reason="TWELVELABS_API_KEY not set",
+)
+def test_embed_text_live():
+    pytest.importorskip("twelvelabs")
+    vec = tla.embed_text("a person walking a dog")
+    assert len(vec) == 512
+    assert all(isinstance(x, float) for x in vec[:5])

--- a/videotrans/configure/config.py
+++ b/videotrans/configure/config.py
@@ -696,6 +696,7 @@ class AppParams:
             "ai302_key": "",
             "ai302_model": "",
             "ai302_model_recogn": "whisper-1",
+            "twelvelabs_key": "",
             "whipserx_api": "http://127.0.0.1:9092",
             
             "trans_api_url": "",

--- a/videotrans/util/twelvelabs_analyze.py
+++ b/videotrans/util/twelvelabs_analyze.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""
+TwelveLabs content-aware video understanding.
+
+An opt-in helper that uses TwelveLabs' Pegasus model to generate a natural
+language description / summary of a video (what happens in it, scene
+breakdown, key topics, etc.) before or alongside the usual
+transcribe -> translate -> dub workflow. It also exposes a Marengo
+multimodal text embedding helper that can be used for semantic search.
+
+This module has no effect on existing behaviour: nothing imports it unless
+the user explicitly runs the `analyze` task. The `twelvelabs` SDK is an
+optional dependency and is imported lazily so the rest of pyVideoTrans keeps
+working when it is not installed.
+
+Get a free API key (generous free tier) at https://twelvelabs.io
+"""
+import base64
+import os
+from pathlib import Path
+from typing import List
+
+from videotrans.configure.config import params, logger
+
+# Pegasus video understanding model and Marengo embedding model.
+PEGASUS_MODEL = "pegasus1.5"
+MARENGO_MODEL = "marengo3.0"
+
+# Videos sent inline (base64) must be <= 1 hour and within Pegasus limits.
+# Larger files should be pre-segmented before calling analyze().
+DEFAULT_PROMPT = (
+    "Describe this video in detail: summarize what happens, list the main "
+    "topics and any on-screen text, and note the overall tone."
+)
+
+
+def _get_api_key() -> str:
+    """Read the TwelveLabs key from saved settings, falling back to env."""
+    key = (params.get("twelvelabs_key", "") or "").strip()
+    if not key:
+        key = (os.environ.get("TWELVELABS_API_KEY", "") or "").strip()
+    return key
+
+
+def _make_client():
+    """Lazily import the SDK and build a client, or raise a clear error."""
+    try:
+        from twelvelabs import TwelveLabs
+    except ImportError as e:
+        raise RuntimeError(
+            "The 'twelvelabs' package is required for TwelveLabs analysis. "
+            "Install it with: uv sync --extra twelvelabs"
+        ) from e
+
+    key = _get_api_key()
+    if not key:
+        raise RuntimeError(
+            "TwelveLabs API key not configured. Set 'twelvelabs_key' in "
+            "settings or the TWELVELABS_API_KEY environment variable. "
+            "Get a free key at https://twelvelabs.io"
+        )
+    return TwelveLabs(api_key=key)
+
+
+def analyze_video(
+    video_path: str,
+    prompt: str = DEFAULT_PROMPT,
+    max_tokens: int = 2048,
+) -> str:
+    """Run Pegasus over a local video file and return the generated text.
+
+    The file is sent inline as base64, so no index/upload step is needed.
+    Suitable for clips up to ~1 hour; segment longer videos first.
+    """
+    from twelvelabs.types import VideoContext_Base64String
+
+    p = Path(video_path)
+    if not p.exists():
+        raise FileNotFoundError(video_path)
+
+    client = _make_client()
+    b64 = base64.b64encode(p.read_bytes()).decode("ascii")
+
+    logger.info(f"TwelveLabs Pegasus analyzing {p.name} (prompt={prompt!r})")
+    resp = client.analyze(
+        model_name=PEGASUS_MODEL,
+        video=VideoContext_Base64String(base_64_string=b64),
+        prompt=prompt,
+        max_tokens=max_tokens,
+    )
+    return resp.data or ""
+
+
+def embed_text(text: str) -> List[float]:
+    """Return the 512-dim Marengo embedding for a text query.
+
+    Useful for semantic search over content analyzed with Pegasus.
+    """
+    client = _make_client()
+    resp = client.embed.create(model_name=MARENGO_MODEL, text=text)
+    segments = (resp.text_embedding.segments if resp.text_embedding else None) or []
+    if not segments or not segments[0].float_:
+        raise RuntimeError("TwelveLabs returned no embedding")
+    return segments[0].float_
+
+
+if __name__ == "__main__":
+    # ponytail: no-network self-check — verifies key/SDK wiring without a video.
+    # A real embedding call runs only when TWELVELABS_API_KEY is set.
+    import sys
+
+    if os.environ.get("TWELVELABS_API_KEY"):
+        vec = embed_text("a person walking a dog")
+        assert len(vec) == 512, f"expected 512-dim, got {len(vec)}"
+        print(f"OK: Marengo embedding dim={len(vec)}")
+    else:
+        # Missing key must raise a clear, actionable error.
+        try:
+            _make_client()
+        except RuntimeError as e:
+            assert "API key" in str(e) or "twelvelabs" in str(e).lower()
+            print("OK: missing-key path raises clear error")
+            sys.exit(0)


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

This PR adds an **opt-in, content-aware video understanding** capability alongside the existing transcribe / translate / dub workflow, using TwelveLabs' [Pegasus](https://twelvelabs.io) video-understanding model.

### What it adds
- **`cli.py --task analyze`** — runs Pegasus over a local video and writes a natural-language summary/description to `<name>.analyze.txt`. Supports `--tl_prompt` (ask anything about the video) and `--tl_max_tokens`. The file is sent inline (base64), so there's no index/upload/polling step for clips up to ~1 hour.
- **`videotrans/util/twelvelabs_analyze.py`** — a small helper (`analyze_video`, plus a Marengo `embed_text` for 512-dim semantic-search embeddings). The `twelvelabs` SDK is imported lazily.
- Config: `twelvelabs_key` (or the `TWELVELABS_API_KEY` env var) — mirrors how other API providers read their keys.
- Optional dependency `twelvelabs` extra: `uv sync --extra twelvelabs`.
- Docs (README + docs/cli.md, with a Chinese section matching the existing doc) and tests.

### Why it helps this project
pyVideoTrans already understands what people *say* in a video. This lets a user also understand what a video *is about* — a quick summary, topic list, on-screen text, or any custom question — before committing to a full translation/dubbing run.

### Opt-in / non-breaking
Nothing imports the SDK unless the new `analyze` task runs. No defaults changed, no existing task touched; the analyze path is dispatched standalone (no GPU/SRT/cache setup).

### How it was tested
- `tests/test_twelvelabs_analyze.py`: no-network wiring tests (SDK mocked) for key resolution, `analyze` request params, embedding shape, and CLI arg registration; plus a live test gated on `TWELVELABS_API_KEY`.
- Ran locally with a real key: the live Marengo call returns a 512-dim vector and the full focused suite passes (10/10). `ruff` clean on the new files. Existing `tests/test_cli.py` still passes (77/77).
- Pegasus request wiring is verified by tests; a full end-to-end analyze run against a real video is straightforward but slower, so it's exercised via the mocked wiring test here.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.