### PR TITLE
Fix Microsoft Edge translate after auth endpoint removal

### DIFF
--- a/videotrans/translator/_microsoft.py
+++ b/videotrans/translator/_microsoft.py
@@ -15,15 +15,13 @@ from videotrans.translator._base import BaseTrans
 @dataclass
 class Microsoft(BaseTrans):
 
+    def __post_init__(self):
+        super().__post_init__()
+        self.api_url = 'https://edge.microsoft.com/translate/translatetext'
+
     @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO),after=after_log(logger, logging.INFO))
     def _item_task(self, data: Union[List[str], str]) -> str:
         if self._exit(): return
-        headers = {
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-        }
-
-        auth = requests.get('https://edge.microsoft.com/translate/auth', headers=headers, verify=False)
-        auth.raise_for_status()
         if not self.target_code:
             raise StopRetry(tr("The target language code is not set correctly and cannot be translated"))
         tocode = self.target_code
@@ -31,13 +29,22 @@ class Microsoft(BaseTrans):
             tocode = 'zh-Hans'
         elif tocode.lower() == 'zh-tw':
             tocode = 'zh-Hant'
-        url = f"https://api-edge.cognitive.microsofttranslator.com/translate?from=&to={tocode}&api-version=3.0&includeSentenceLength=true"
-        headers['Authorization'] = f"Bearer {auth.text}"
-        response = requests.post(url, json=[{"Text": "\n".join(data)}], headers=headers,
-                                 verify=False, timeout=300)
-        logger.debug(f'[Mircosoft]返回:{response=}')
+
+        texts = data if isinstance(data, list) else [data]
+        url = f"{self.api_url}?from=&to={tocode}&isEnterpriseClient=false"
+        headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+            'Content-Type': 'application/json',
+        }
+        response = requests.post(url, json=texts, headers=headers, verify=False, timeout=300)
+        logger.debug(f'[Microsoft]返回:{response=}')
         response.raise_for_status()
         re_result = response.json()
-        if len(re_result) == 0 or len(re_result[0]['translations']) == 0:
+        if not re_result:
             raise TranslateSrtError(f'no result:{re_result=}')
-        return re_result[0]['translations'][0]['text'].strip()
+        lines = []
+        for item in re_result:
+            if not item.get('translations'):
+                raise TranslateSrtError(f'no result:{re_result=}')
+            lines.append(item['translations'][0]['text'].strip())
+        return "\n".join(lines)

--- a/videotrans/translator/_runner.py
+++ b/videotrans/translator/_runner.py
@@ -21,8 +21,13 @@ def _check_gorm(name='google'):
             requests.head(f"https://translate.google.com", timeout=5,verify=False,headers=headers)
             return True
 
-        auth = requests.head('https://edge.microsoft.com/translate/auth', headers=headers, verify=False)
-        if not auth or auth.status_code==404:
+        auth = requests.head(
+            'https://edge.microsoft.com/translate/translatetext',
+            headers=headers,
+            verify=False,
+            timeout=5,
+        )
+        if not auth or auth.status_code == 404:
             return False
     except Exception as e:
         logger.exception(f'检测 {name} 翻译失败{e}', exc_info=True)


### PR DESCRIPTION
  Switch to the unauthenticated /translate/translatetext API and update the health check so Microsoft translate is not falsely marked unavailable.

Ref: https://www.ankio.net/research/technology/microsoft-edge-translate-api
