### PR TITLE
fix: raise NotImplementedError instead of NotImplemented in the three abstract stubs

### DIFF
--- a/videotrans/recognition/_base.py
+++ b/videotrans/recognition/_base.py
@@ -143,7 +143,7 @@ class BaseRecogn(BaseCon):
         return srt_list
 
     def _exec(self) -> Union[List[SrtItem], None]:
-        raise NotImplemented()
+        raise NotImplementedError()
 
     # 有些识别渠道需要预先使用VAD切割为合适时长的音频片段，然后再对片段识别，每个识别结果即为一条字幕
     # whisper模型并且没有选中预先分割，无需切割

--- a/videotrans/translator/_base.py
+++ b/videotrans/translator/_base.py
@@ -53,7 +53,7 @@ class BaseTrans(BaseCon):
             self.trans_thread = int(settings.get('trans_thread', 5))
 
     def _item_task(self, data: Union[List[str], str]):
-        raise NotImplemented()
+        raise NotImplementedError()
 
     # 实际操作 run  -> run_text|run_srt -> _item_task
     def run(self) -> List[SrtItem]:

--- a/videotrans/tts/_base.py
+++ b/videotrans/tts/_base.py
@@ -219,7 +219,7 @@ class BaseTTS(BaseCon):
 
     # 子类未重写 _exec 方法时，则必须实现该方法
     def _run(self, data_item: Union[Dict, List, None], idx: int = -1) -> Union[str, None]:
-        raise NotImplemented
+        raise NotImplementedError
 
     # 文本规范化和清理音量等参数
     def _cleantts(self) -> None:


### PR DESCRIPTION
## Problem

Three abstract-method guards in the base classes raise `NotImplemented` instead of `NotImplementedError`:

| File | Line | Method |
|---|---|---|
| `videotrans/recognition/_base.py` | 146 | `BaseRecogn._exec` |
| `videotrans/translator/_base.py` | 56 | `BaseTrans._item_task` |
| `videotrans/tts/_base.py` | 222 | `BaseTTS._run` |

`NotImplemented` is a singleton constant (the one `__eq__` returns), **not** an exception class. Raising it does not produce `NotImplementedError` — Python rejects it:

```python
>>> class Base:
...     def _run(self): raise NotImplemented
>>> class Sub(Base): pass
>>> Sub()._run()
TypeError: exceptions must derive from BaseException
```

Verified locally against `main` (`d1cb622`):

```
BEFORE: TypeError: exceptions must derive from BaseException
AFTER:  NotImplementedError:
```

## Why it matters

These three stubs are the contract for anyone adding a new recognition / translation / TTS channel — the comments say so explicitly, e.g. `videotrans/tts/_base.py`:

```python
# 子类未重写 _exec 方法时，则必须实现该方法
def _run(self, data_item, idx=-1): ...
```

When a new subclass forgets to override, the developer should see `NotImplementedError`. Instead:

- **TTS path** — `BaseTTS._item_task` (line 205–218) wraps the call in `except Exception as e: logger.exception(...); return e`. `TypeError` is an `Exception`, so the missing-override is swallowed and reported once per subtitle as `第N条字幕配音失败 … exceptions must derive from BaseException`, which points at the audio data rather than at the missing method.
- **Any `except NotImplementedError` handler** — in this repo or in downstream code — will not catch it, because the raised type is `TypeError`.

## Fix

Three one-character-class changes; no behavioural change on any path that already overrides these methods (all shipped channels do).

The repo already uses the correct form elsewhere — `videotrans/task/job.py:40`:

```python
raise NotImplementedError
```

so this just brings the three outliers in line with the project's own idiom. This is also what `pyflakes` / `ruff F901` flag.

## Scope

3 files, +3 / −3. No public API change, no new dependency, no behaviour change for existing subclasses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
