### PR TITLE
Fix Qwen ASR empty API URL, prevent API key leaks, and fix STT bugs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,4 @@ COPY . .
 
 EXPOSE 7860
 
-CMD ["python", "webui.py"]
+CMD ["python", "webui.py", "--host", "0.0.0.0"]

--- a/docs/webui.md
+++ b/docs/webui.md
@@ -25,11 +25,13 @@ uv sync --extra webui
 启动服务：
 
 ```bash
-uv run webui.py                    # 默认 0.0.0.0:7860
-uv run webui.py --port 8080        # 指定端口
-uv run webui.py --host 127.0.0.1   # 仅本机访问
-uv run webui.py --share            # 创建 Gradio 公网链接
+uv run webui.py                                   # 默认仅本机访问 127.0.0.1:7860
+uv run webui.py --port 8080                       # 指定端口
+uv run webui.py --host 0.0.0.0 --auth 用户名:密码   # 允许局域网访问，并启用登录验证
+uv run webui.py --share --auth 用户名:密码          # 创建 Gradio 公网链接，务必启用登录验证
 ```
+
+> 设置页可以查看和修改各渠道的 API Key。允许其他机器访问（`--host 0.0.0.0` 或 `--share`）时，请务必加上 `--auth`。
 
 访问：`http://127.0.0.1:7860` 或 `http://<服务器IP>:7860`
 
@@ -43,6 +45,9 @@ docker build -t pyvideotrans-webui .
 
 # 运行
 docker run -d -p 7860:7860 --name pyvideotrans pyvideotrans-webui
+
+# 启用登录验证（推荐，容器默认监听 0.0.0.0）
+docker run -d -p 7860:7860 --name pyvideotrans pyvideotrans-webui python webui.py --host 0.0.0.0 --auth 用户名:密码
 
 # 持久化配置和输出
 docker run -d -p 7860:7860 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,7 +298,6 @@ override-dependencies = [
 	"pythonnet ; sys_platform == 'win32'",
 ]
 
-index-strategy = "unsafe-best-match"
 
 
 
@@ -327,12 +326,14 @@ torchaudio = [
 # https://github.com/OpenMOSS/MOSS-TTS-Nano/issues/6
 #  https://github.com/billwuhao/pynini-windows-wheels/releases/download/v2.1.6.post1/pynini-2.1.6.post1-cp310-cp310-win_amd64.whl
 
+# 注意：该 wheel 由第三方账号构建，uv.lock 中已固定 sha256；更换版本时需重新核对来源
 pynini = [
     { url = "https://github.com/billwuhao/pynini-windows-wheels/releases/download/v2.1.6.post1/pynini-2.1.6.post1-cp310-cp310-win_amd64.whl", marker = "sys_platform == 'win32'" }
 ]
 
 
 #faster-whisper = { url = "https://github.com/SYSTRAN/faster-whisper/archive/refs/heads/master.tar.gz" }
-chatterbox-tts = { url = "https://github.com/resemble-ai/chatterbox/archive/refs/heads/master.tar.gz" }
+# 固定到具体提交（内容与原 master 锁定版本一致），避免 master 变动后重新锁定时拉取未审查的代码
+chatterbox-tts = { url = "https://github.com/resemble-ai/chatterbox/archive/5de7a54aa4e5e2baadb0182dde554908b48b85c2.tar.gz" }
 
 

--- a/tests/test_security_stt_fixes.py
+++ b/tests/test_security_stt_fixes.py
@@ -1,0 +1,235 @@
+import json
+import logging
+import sys
+from unittest import mock
+
+from videotrans.configure._redact import RedactFilter, redact
+from videotrans.configure.config import params, settings
+from videotrans.recognition._base import BaseRecogn
+
+
+class TestRedact:
+    def test_query_bearer_and_known_formats(self):
+        text = ("POST http://127.0.0.1:1188/translate?key=abcdef123456&x=1\n"
+                "Authorization: Bearer abcdefghijklmnopqrstuvwxyz\n"
+                "sk-abcdefghijklmnopqrstuvwxyz hf_abcdefghijklmnopqrstuvwxyz")
+        result = redact(text)
+        assert "abcdef123456" not in result
+        assert "abcdefghijklmnopqrstuvwxyz" not in result
+        assert "?key=***&x=1" in result
+
+    def test_configured_secret_value(self):
+        old = params.get('deeplx_key', '')
+        params['deeplx_key'] = 'my-deeplx-secret-value'
+        try:
+            assert 'my-deeplx-secret-value' not in redact('failed: my-deeplx-secret-value')
+        finally:
+            params['deeplx_key'] = old
+
+    def test_max_token_values_not_redacted(self):
+        old = params.get('chatgpt_max_token', '')
+        params['chatgpt_max_token'] = '12345678'
+        try:
+            assert redact('max 12345678') == 'max 12345678'
+        finally:
+            params['chatgpt_max_token'] = old
+
+    def test_log_filter_redacts_message_and_traceback(self):
+        record = logging.LogRecord('VideoTrans', logging.ERROR, __file__, 1, 'url=%s',
+                                   ('http://h/?sk=abcdef123456',), None)
+        try:
+            raise ValueError('http://h/?key=zyxwvu987654')
+        except ValueError:
+            record.exc_info = sys.exc_info()
+        assert RedactFilter().filter(record) is True
+        assert 'abcdef123456' not in record.getMessage()
+        assert 'zyxwvu987654' not in record.exc_text
+
+
+class TestRecognitionBase:
+    def test_cjk_job_does_not_mutate_shared_punctuation(self):
+        from videotrans.configure import contants
+        before = list(contants.PUNC_FLAGS)
+        BaseRecogn(detect_language="zh-cn")
+        assert contants.PUNC_FLAGS == before
+        assert " " not in BaseRecogn(detect_language="en").flag
+
+    def test_asr_wait_reads_current_setting(self):
+        old = settings.get('asr_wait', 0)
+        settings['asr_wait'] = 3
+        try:
+            assert BaseRecogn().asr_wait == 3
+        finally:
+            settings['asr_wait'] = old
+
+    def test_stop_after_retry_nums_reads_setting_each_time(self):
+        from videotrans.configure._retry import stop_after_retry_nums
+        state = mock.Mock(attempt_number=2)
+        old = settings.get('retry_nums', 1)
+        try:
+            settings['retry_nums'] = 3
+            assert stop_after_retry_nums()(state) is False
+            settings['retry_nums'] = 2
+            assert stop_after_retry_nums()(state) is True
+        finally:
+            settings['retry_nums'] = old
+
+
+def _xxl_cls():
+    from videotrans.recognition import _xxl
+    return next(v for v in vars(_xxl).values()
+                if isinstance(v, type) and issubclass(v, BaseRecogn) and v is not BaseRecogn)
+
+
+def test_xxl_parses_all_consecutive_lines(tmp_path):
+    content = "\n".join([
+        "[00:00.000 --> 00:01.500] one",
+        "[00:01.500 --> 00:03.000] two",
+        "[00:03.000 --> 00:04.000]  three ",
+        "[01:00:04.000 --> 01:00:05.250] four",
+    ]) + "\n"
+    cls = _xxl_cls()
+    out = tmp_path / "a.srt"
+    cls._getsrt_from_stdout(cls, content, str(out))
+    text = out.read_text(encoding='utf-8')
+    assert text.count(" --> ") == 4
+    assert "\nthree" in text
+    assert "01:00:04,000 --> 01:00:05,250" in text
+
+
+def test_recognapi_accepts_srt_string_and_keeps_url_case(tmp_path):
+    from videotrans.recognition import _recognapi
+    audio = tmp_path / "a.wav"
+    audio.write_bytes(b"RIFF")
+    srt = "1\n00:00:00,000 --> 00:00:01,000\nhello\n\n2\n00:00:01,000 --> 00:00:02,000\nworld\n"
+    resp = mock.Mock(headers={"Content-Type": "application/json"})
+    resp.json.return_value = {"code": 0, "data": srt}
+    old_url, old_key = params.get('recognapi_url', ''), params.get('recognapi_key', '')
+    params['recognapi_url'] = 'http://127.0.0.1:9977/API/Recogn'
+    params['recognapi_key'] = ''
+    try:
+        rec = _recognapi.APIRecogn(detect_language="en", audio_file=str(audio), cache_folder=str(tmp_path))
+        assert rec.api_url == 'http://127.0.0.1:9977/API/Recogn'
+        with mock.patch.object(_recognapi.requests, "post", return_value=resp), \
+                mock.patch.object(rec, "signal"), mock.patch.object(rec, "_exit", return_value=False):
+            raws = rec._exec()
+    finally:
+        params['recognapi_url'], params['recognapi_key'] = old_url, old_key
+    assert [it['text'] for it in raws] == ['hello', 'world']
+
+
+def test_ai302_diarize_speaker_ids_are_stable(tmp_path):
+    from videotrans.recognition import _ai302
+    audio = tmp_path / "a.wav"
+    audio.write_bytes(b"RIFF")
+    segs = [{"start": i, "end": i + 1, "text": f"t{i}", "speaker": sp}
+            for i, sp in enumerate(["A", "B", "A", "C", "C", None])]
+    resp = mock.Mock()
+    resp.json.return_value = {"segments": segs}
+    rec = _ai302.AI302Recogn(detect_language="en", audio_file=str(audio), cache_folder=str(tmp_path))
+    with mock.patch.object(_ai302.requests, "post", return_value=resp):
+        raws = rec._diarize()
+    assert len(raws) == 6
+    speakers = json.loads((tmp_path / "speaker.json").read_text(encoding="utf-8"))
+    assert speakers == ["spk0", "spk1", "spk0", "spk2", "spk2", "spk3"]
+
+
+def test_ai302_gpt4o_uses_filename_field(tmp_path):
+    from videotrans.recognition import _ai302
+    chunk = tmp_path / "0.wav"
+    chunk.write_bytes(b"RIFF")
+    resp = mock.Mock()
+    resp.json.return_value = {"text": "hello"}
+    rec = _ai302.AI302Recogn(detect_language="en", cache_folder=str(tmp_path))
+    rec.asr_wait = 0
+    with mock.patch.object(rec, "cut_audio", return_value=[{"filename": str(chunk), "text": ""}]), \
+            mock.patch.object(_ai302.requests, "post", return_value=resp):
+        raws = rec._thrid_api()
+    assert raws[0]["text"] == "hello"
+
+
+def test_gemini_summary_uses_absolute_times(tmp_path):
+    from videotrans.recognition import _gemini
+
+    def word(text, start, end):
+        return mock.Mock(text=text, start_offset=f"{start}s", end_offset=f"{end}s")
+
+    chunks = [{"filename": "a", "start_time": 0}, {"filename": "b", "start_time": 300000}]
+    rec = _gemini.GeminiRecogn(detect_language="en", cache_folder=str(tmp_path))
+    rec.asr_wait = 0
+    captured = {}
+
+    def fake_resegment(texts, *args, **kwargs):
+        captured['texts'] = texts
+        return []
+
+    with mock.patch.object(rec, "_cut", return_value=chunks), \
+            mock.patch.object(rec, "_req", side_effect=[([word("a", 1, 2), word("b", 250, 251)], "a b"),
+                                                        ([word("c", 3, 4)], "c")]), \
+            mock.patch.object(rec, "signal"), \
+            mock.patch.object(_gemini, "_resegment", side_effect=fake_resegment):
+        rec._exec()
+    summary = captured['texts'][0]
+    assert summary['start'] == 1
+    assert summary['end'] == 304
+    assert summary['text'] == "a b c"
+
+
+def test_qwen_flash_skips_segment_blocked_by_inspection(tmp_path):
+    from videotrans.recognition import _qwen3asr
+    files = []
+    for i in range(2):
+        f = tmp_path / f"{i}.wav"
+        f.write_bytes(b"RIFF")
+        files.append({"filename": str(f), "text": ""})
+    blocked = mock.Mock(status_code=400, text='{"code":"DataInspectionFailed"}')
+    ok = mock.Mock(status_code=200, text='{}')
+    ok.json.return_value = {"output": {"text": "hello"}}
+    with mock.patch.object(_qwen3asr.Qwen3ASRRecogn, "cut_audio", return_value=files):
+        rec = _qwen3asr.Qwen3ASRRecogn(detect_language="zh-cn", model_name="fun-asr-flash-2026-06-15")
+    rec.asr_wait = 0
+    with mock.patch.object(_qwen3asr.requests, "post", side_effect=[blocked, ok]) as post, \
+            mock.patch.object(rec, "signal"), mock.patch.object(rec, "_exit", return_value=False):
+        raws = rec._audio_funasr_flash("sk-test", rec.model_name)
+    assert [it["text"] for it in raws] == ["", "hello"]
+    for call in post.call_args_list:
+        assert "timeout" in call.kwargs
+        assert "verify" not in call.kwargs
+
+
+def test_glmasr_retries_on_rate_limit(tmp_path):
+    from videotrans.recognition import _glmasr
+    chunk = tmp_path / "0.wav"
+    chunk.write_bytes(b"RIFF")
+    limited = mock.Mock(status_code=429, text="limited")
+    limited.json.return_value = {"error": {"code": "1302", "message": "rate limited"}}
+    ok = mock.Mock(status_code=200)
+    ok.json.return_value = {"text": " hi "}
+    rec = _glmasr.GLMASRRecogn(detect_language="zh-cn")
+    rec.asr_wait = 0
+    with mock.patch.object(rec, "cut_audio", return_value=[{"filename": str(chunk), "text": ""}]), \
+            mock.patch.object(_glmasr.requests, "post", side_effect=[limited, ok]), \
+            mock.patch.object(_glmasr.time, "sleep"), \
+            mock.patch.object(rec, "signal"), mock.patch.object(rec, "_exit", return_value=False):
+        raws = rec._exec()
+    assert raws[0]["text"] == "hi"
+
+
+def test_is_input_api_names_actual_channel():
+    from videotrans import recognition
+    old = params.get('qwenmt_key', '')
+    params['qwenmt_key'] = ''
+    try:
+        msg = recognition.is_input_api(recognition.QWEN3ASR, return_str=True)
+    finally:
+        params['qwenmt_key'] = old
+    assert "Deepgram" not in msg
+    assert "Qwen" in msg
+
+
+def test_update_ffmpeg_selects_stable_build_and_checksum():
+    from videotrans.task import update_ffmpeg as uf
+    assert uf._stable_version("ffmpeg-n8.1-latest-win64-gpl-8.1.zip") == (8, 1)
+    assert uf._stable_version("ffmpeg-n8.1-latest-win64-gpl-shared-8.1.zip") is None
+    text = "aaa  ffmpeg-master-latest-win64-gpl.zip\nBBB  ffmpeg-n8.1-latest-win64-gpl-8.1.zip\n"
+    assert uf._expected_sha256(text, "ffmpeg-n8.1-latest-win64-gpl-8.1.zip") == "bbb"

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 
 [manifest]
 overrides = [
-    { name = "chatterbox-tts", url = "https://github.com/resemble-ai/chatterbox/archive/refs/heads/master.tar.gz" },
+    { name = "chatterbox-tts", url = "https://github.com/resemble-ai/chatterbox/archive/5de7a54aa4e5e2baadb0182dde554908b48b85c2.tar.gz" },
     { name = "diffusers", specifier = "==0.33.1" },
     { name = "f5-tts", specifier = "==1.1.20" },
     { name = "google-cloud-storage", specifier = "==3.12.0" },
@@ -746,7 +746,7 @@ wheels = [
 [[package]]
 name = "chatterbox-tts"
 version = "0.1.7"
-source = { url = "https://github.com/resemble-ai/chatterbox/archive/refs/heads/master.tar.gz" }
+source = { url = "https://github.com/resemble-ai/chatterbox/archive/5de7a54aa4e5e2baadb0182dde554908b48b85c2.tar.gz" }
 dependencies = [
     { name = "conformer" },
     { name = "diffusers" },
@@ -769,7 +769,7 @@ dependencies = [
     { name = "torchaudio", version = "2.7.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or sys_platform == 'win32'" },
     { name = "transformers" },
 ]
-sdist = { hash = "sha256:6a51eaa0b82cd28e59e5c6d2cb4b41ced0b4b221b85b97376b70c5bf8251cb12" }
+sdist = { hash = "sha256:003f8c85dcfeb2d91b3a6f97f43b74703d15131e987dfabb7f3d9aee7c0da2cf" }
 
 [package.metadata]
 requires-dist = [
@@ -4595,7 +4595,7 @@ requires-dist = [
     { name = "cffi", specifier = "==1.17.1" },
     { name = "chardet", specifier = "==3.0.4" },
     { name = "charset-normalizer", specifier = "==3.4.4" },
-    { name = "chatterbox-tts", url = "https://github.com/resemble-ai/chatterbox/archive/refs/heads/master.tar.gz" },
+    { name = "chatterbox-tts", url = "https://github.com/resemble-ai/chatterbox/archive/5de7a54aa4e5e2baadb0182dde554908b48b85c2.tar.gz" },
     { name = "click", specifier = "==8.1.7" },
     { name = "colorama", specifier = "==0.4.6" },
     { name = "coloredlogs", specifier = "==15.0.1" },

--- a/videotrans/configure/_logging.py
+++ b/videotrans/configure/_logging.py
@@ -6,6 +6,7 @@ import sys
 import time
 
 from videotrans.configure._paths import ROOT_DIR
+from videotrans.configure._redact import RedactFilter
 
 
 def _set_logs():
@@ -16,12 +17,15 @@ def _set_logs():
                                         encoding='utf-8')
     _file_handler.setLevel(logging.DEBUG)
     _file_handler.setFormatter(formatter)
+    # 写入日志前脱敏，避免 API Key 出现在日志文件中
+    _file_handler.addFilter(RedactFilter())
     logger.addHandler(_file_handler)
 
     if sys.stdout is not None:
         _console_handler = logging.StreamHandler(sys.stdout)
         _console_handler.setLevel(logging.WARNING)
         _console_handler.setFormatter(formatter)
+        _console_handler.addFilter(RedactFilter())
         logger.addHandler(_console_handler)
 
     logging.getLogger("transformers").setLevel(logging.DEBUG)

--- a/videotrans/configure/_redact.py
+++ b/videotrans/configure/_redact.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+敏感信息脱敏：用于日志、错误弹窗和报错链接，避免 API Key 等密钥泄露
+"""
+import logging
+import re
+import threading
+
+# 配置项名称以这些结尾时视为密钥，max_token 这类数值配置除外
+_SECRET_NAME_RE = re.compile(r'(key|secret|secretid|token)$', re.I)
+_NOT_SECRET_NAME_RE = re.compile(r'max_?tokens?$', re.I)
+_MIN_SECRET_LEN = 6
+
+_PATTERNS = [
+    # URL 查询参数中的密钥，如 ?key=xxx、&sk=xxx、&secret=xxx
+    (re.compile(r'([?&](?:key|sk|secret|token|api_key|apikey|access_token|auth_key)=)[^&\s\'"<>]+', re.I), r'\1***'),
+    # Authorization: Bearer xxx
+    (re.compile(r'(Bearer\s+)[A-Za-z0-9._~+/=-]{8,}', re.I), r'\1***'),
+    # 常见密钥格式
+    (re.compile(r'\bsk-[A-Za-z0-9_-]{16,}'), 'sk-***'),
+    (re.compile(r'\bAIza[0-9A-Za-z_-]{30,}'), 'AIza***'),
+    (re.compile(r'\bhf_[A-Za-z0-9]{20,}'), 'hf_***'),
+]
+
+_local = threading.local()
+
+
+def _configured_secrets():
+    """读取当前配置中已填写的密钥值"""
+    secrets = set()
+    try:
+        from videotrans.configure.config import params, settings
+        items = list(params.to_dict().items())
+        items.append(('hf_token', settings.get('hf_token', '')))
+    except Exception:
+        return secrets
+    for name, value in items:
+        if not isinstance(value, str) or not _SECRET_NAME_RE.search(name) or _NOT_SECRET_NAME_RE.search(name):
+            continue
+        # gemini_key 等支持逗号分隔多个 Key
+        for part in value.split(','):
+            part = part.strip()
+            if len(part) >= _MIN_SECRET_LEN and not part.isdigit():
+                secrets.add(part)
+    return secrets
+
+
+def redact(text):
+    """把文本中的密钥替换为 ***"""
+    if not text:
+        return text
+    text = str(text)
+    for secret in sorted(_configured_secrets(), key=len, reverse=True):
+        if secret in text:
+            text = text.replace(secret, '***')
+    for pattern, repl in _PATTERNS:
+        text = pattern.sub(repl, text)
+    return text
+
+
+class RedactFilter(logging.Filter):
+    """日志处理器过滤器：写入前对消息和异常堆栈脱敏"""
+
+    def filter(self, record):
+        # 读取配置时可能再次写日志，避免递归
+        if getattr(_local, 'busy', False):
+            return True
+        _local.busy = True
+        try:
+            msg = record.getMessage()
+            redacted = redact(msg)
+            if redacted != msg:
+                record.msg = redacted
+                record.args = None
+            if record.exc_info and not record.exc_text:
+                record.exc_text = redact(logging.Formatter().formatException(record.exc_info))
+        except Exception:
+            pass
+        finally:
+            _local.busy = False
+        return True

--- a/videotrans/configure/_retry.py
+++ b/videotrans/configure/_retry.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from tenacity.stop import stop_base
+
+
+class stop_after_retry_nums(stop_base):
+    """按设置中的重试次数停止重试。每次判断时实时读取设置，修改后无需重启即可生效"""
+
+    def __init__(self, key: str = 'retry_nums'):
+        self.key = key
+
+    def __call__(self, retry_state) -> bool:
+        from videotrans.configure.config import settings
+        try:
+            max_attempts = int(float(settings.get(self.key, 1) or 1))
+        except (TypeError, ValueError):
+            max_attempts = 1
+        return retry_state.attempt_number >= max(max_attempts, 1)

--- a/videotrans/recognition/__init__.py
+++ b/videotrans/recognition/__init__.py
@@ -132,9 +132,10 @@ HUGGINGFACE_ASR_MODELS = {
 try:
     if Path(f'{ROOT_DIR}/huggingface_models.txt').exists():
         for it in Path(f'{ROOT_DIR}/huggingface_models.txt').read_text(encoding='utf-8').strip().split("\n"):
-            HUGGINGFACE_ASR_MODELS[it.strip()] = []
+            if it.strip():
+                HUGGINGFACE_ASR_MODELS[it.strip()] = []
 except Exception as e:
-    logger.waring(f'添加自定义 Huggingface_ASR 模型失败:{e}')
+    logger.warning(f'添加自定义 Huggingface_ASR 模型失败:{e}')
 
 
 def get_model_by_type(recogn_type: int) -> List[str]:
@@ -189,7 +190,7 @@ def is_input_api(recogn_type: int = None, return_str=False):
     _cls = _ID_NAME_DICT.get(recogn_type)
     if not _cls: return True
     if _cls.key_name and not params.get(_cls.key_name):
-        return "Please configure the API Key information of the Deepgram channel first." if return_str else winform.get_win(
+        return f"Please configure the API Key information of the {_cls.name} channel first." if return_str else winform.get_win(
             _cls.win).openwin()
     return True
 

--- a/videotrans/recognition/_ai302.py
+++ b/videotrans/recognition/_ai302.py
@@ -6,6 +6,7 @@ from typing import List,  Union
 
 import requests
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type, before_log, after_log
+from videotrans.configure._retry import stop_after_retry_nums
 from videotrans.configure.config import params,settings,logger
 from videotrans.configure.excepts import NO_RETRY_EXCEPT, SpeechToTextError
 from videotrans.recognition._base import BaseRecogn
@@ -16,7 +17,7 @@ from videotrans.util._srt_parse import ms_to_time_string
 @dataclass
 class AI302Recogn(BaseRecogn):
 
-    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
+    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=stop_after_retry_nums(), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
     def _exec(self) -> Union[List[SrtItem], None]:
         if self._exit(): return
         self.signal(text=f"start speech to srt")
@@ -88,7 +89,7 @@ class AI302Recogn(BaseRecogn):
             with open(it['filename'], 'rb') as f:
                 audio_chunk = f.read()
             response = requests.post(url,
-                 files={"file": (Path(it['file']).name, audio_chunk)},
+                 files={"file": (Path(it['filename']).name, audio_chunk)},
                  data={
                      "model": model_name,
                      'response_format': 'json',
@@ -149,14 +150,11 @@ class AI302Recogn(BaseRecogn):
                     ms=it['end'] * 1000),
             ))
 
-            sp=it.get('speaker')
-            if not sp:
-                speaker_list.append(f'spk{len(speaker_list)}')
-            elif sp in speaker_name:
-                speaker_list.append(f'spk{speaker_name.index(sp)}')
-            else:
-                speaker_list.append(f'spk{len(speaker_list)}')
+            sp=it.get('speaker') or '-'
+            # 按说话人首次出现的顺序编号，保证同一说话人编号一致
+            if sp not in speaker_name:
                 speaker_name.append(sp)
+            speaker_list.append(f'spk{speaker_name.index(sp)}')
 
         if speaker_list:
             Path(f'{self.cache_folder}/speaker.json').write_text(json.dumps(speaker_list), encoding='utf-8')

--- a/videotrans/recognition/_base.py
+++ b/videotrans/recognition/_base.py
@@ -58,19 +58,23 @@ class BaseRecogn(BaseCon):
     # 当前需进行的是否是二次识别
     recogn2pass: bool = False
     # 每次识别后等待时间，用于在线API，防止超频
-    asr_wait: float = float(settings.get('asr_wait', 0))
+    # 为 None 时在实例化时读取设置，修改设置后无需重启即可生效
+    asr_wait: Optional[float] = None
     # 本地模型存放目录
     local_dir: str = None
 
     def __post_init__(self):
         super().__post_init__()
         self.device = 'cuda' if self.is_cuda else 'cpu'
+        if self.asr_wait is None:
+            self.asr_wait = float(settings.get('asr_wait', 0) or 0)
         # 常见标点
-        self.flag = contants.PUNC_FLAGS
+        # 复制一份，避免下方追加空格时修改全局常量，影响后续任务
+        self.flag = list(contants.PUNC_FLAGS)
         # 逗号等软性标点
-        self.half_flag = contants.PUNC_FLAGS_HALF
+        self.half_flag = list(contants.PUNC_FLAGS_HALF)
         # 句子终止标点
-        self.end_flag = contants.PUNC_FLAGS_END
+        self.end_flag = list(contants.PUNC_FLAGS_END)
         # 连接字符 中日韩粤语高棉语泰国语 直接连接，无需空格，其他语言空格连接
         self.join_word_flag = " "
         # 是中日韩文字

--- a/videotrans/recognition/_camb.py
+++ b/videotrans/recognition/_camb.py
@@ -9,6 +9,7 @@ from typing import List,  Union
 
 import httpx
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type, before_log, after_log
+from videotrans.configure._retry import stop_after_retry_nums
 
 from videotrans.configure.excepts import NO_RETRY_EXCEPT, StopRetry
 from videotrans.configure.config import tr, params, settings,  logger, ROOT_DIR
@@ -34,7 +35,7 @@ def _get_camb_lang_id(langcode):
 @dataclass
 class CambRecogn(BaseRecogn):
 
-    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
+    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=stop_after_retry_nums(), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
     def _exec(self) -> Union[List[SrtItem], None]:
         if self._exit():
             return

--- a/videotrans/recognition/_deepgram.py
+++ b/videotrans/recognition/_deepgram.py
@@ -13,6 +13,7 @@ from deepgram import (
 )
 from deepgram_captions import DeepgramConverter, srt
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type, before_log, after_log
+from videotrans.configure._retry import stop_after_retry_nums
 from videotrans.configure.excepts import NO_RETRY_EXCEPT
 from videotrans.configure.config import tr,params,settings,logger
 from videotrans.recognition._base import BaseRecogn
@@ -25,7 +26,7 @@ from videotrans.util._srt_parse import ms_to_time_string, get_subtitle_from_srt
 @dataclass
 class DeepgramRecogn(BaseRecogn):
 
-    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
+    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=stop_after_retry_nums(), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
     def _exec(self) -> Union[List[SrtItem], None]:
         if self._exit(): return
         import zhconv    

--- a/videotrans/recognition/_elevenlabs.py
+++ b/videotrans/recognition/_elevenlabs.py
@@ -5,6 +5,7 @@ from typing import List, Union
 import httpx
 from elevenlabs import ElevenLabs
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type, before_log, after_log
+from videotrans.configure._retry import stop_after_retry_nums
 from videotrans.configure.config import  params, settings, logger
 from videotrans.configure.excepts import NO_RETRY_EXCEPT
 from videotrans.recognition._base import BaseRecogn
@@ -15,7 +16,7 @@ from videotrans.util._srt_parse import ms_to_time_string
 @dataclass
 class ElevenLabsRecogn(BaseRecogn):
 
-    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
+    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=stop_after_retry_nums(), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
     def _exec(self) -> Union[List[SrtItem], None]:
         if self._exit(): return
 

--- a/videotrans/recognition/_gemini.py
+++ b/videotrans/recognition/_gemini.py
@@ -7,6 +7,7 @@ from typing import List, Union
 from google import genai
 from google.genai import types,errors
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type, before_log, after_log
+from videotrans.configure._retry import stop_after_retry_nums
 
 from videotrans.configure.excepts import NO_RETRY_EXCEPT, StopRetry, SpeechToTextError,StopTask
 from videotrans.configure.config import params, logger,  settings,tr
@@ -29,7 +30,7 @@ class GeminiRecogn(BaseRecogn):
         if self.model_name not in GEMINI_ASR_MODELS.split(','):
             self.model_name='gemini-3.5-transcribe'
 
-    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
+    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=stop_after_retry_nums(), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
     def _req(self,file):
         client=None
         try:
@@ -74,6 +75,8 @@ class GeminiRecogn(BaseRecogn):
             logger.error(str(e))
             if e.code in [400,403,404,429,500]:
                 raise StopRetry(e.message)
+            # 其他错误（如 502/503）继续抛出，交给重试处理
+            raise
         finally:
             if client:
                 client.close()
@@ -91,23 +94,28 @@ class GeminiRecogn(BaseRecogn):
         }]
         _min_speech = max(int(float(settings.get('min_speech_duration_ms', 1000))), 1000)
         _max_speech = max(min(int(float(settings.get('max_speech_duration_s', 6)) * 1000), 20000), _min_speech + 1000)
-        for i,it in enumerate(srts):                       
+        _texts = []
+        for i,it in enumerate(srts):
             words,_text=self._req(it['filename'])
             offset = it['start_time'] / 1000.0
-            for j,w in enumerate(words):
+            for w in words or []:
                 st=float(w.start_offset.replace('s',''))
                 et=float(w.end_offset.replace('s',''))
-                if i==0:
-                    texts[0]['start']=st
+                # 汇总条目的起止时间使用加上片段偏移后的绝对时间
+                if not texts[0]['words']:
+                    texts[0]['start']=st + offset
                 texts[0]['words'].append({"word": w.text, "start": st + offset, "end": et + offset})
-                if i==len(srts)-1 and j==len(words)-1:
-                    texts[0]['end']=et
+                texts[0]['end']=et + offset
+            if _text:
+                _texts.append(_text.strip())
             self.signal(
-                text=f"{_text[:60]}...\n",
+                text=f"{(_text or '')[:60]}...\n",
                 type='subtitle'
             )
             if self.asr_wait>0:
                 time.sleep(self.asr_wait)
+        # 整体时长未超出限制时，_resegment 会直接把该文本作为一条字幕
+        texts[0]['text'] = self.join_word_flag.join(_texts)
         srt_str_list = _resegment(texts, self.detect_language, _max_speech, _min_speech, f"{self.cache_folder}/gemini-stt.log")
         return srt_str_list
 

--- a/videotrans/recognition/_glmasr.py
+++ b/videotrans/recognition/_glmasr.py
@@ -31,16 +31,14 @@ class GLMASRRecogn(BaseRecogn):
                 "stream": "false"
             }
             headers = {"Authorization": f"Bearer {apikey}"}
-            retry=0
+            # 限流(1302/1303/1214)时等待后重试，至少重试 3 次；其他错误直接报错
+            rate_limited=0
+            max_rate_limited=max(int(settings.get('retry_nums', 1) or 1), 3)
             while 1:
-                if retry>=settings.get('retry_nums'):
-                    it['text']=''
-                    break
-                response = requests.post(url, data=payload, files=files, headers=headers)
+                response = requests.post(url, data=payload, files=files, headers=headers, timeout=(30, 300))
                 if response.status_code in [401,403,404,422]:
                     raise StopTask(response.text)
-                retry+=1
-                if response.status_code==200:                    
+                if response.status_code==200:
                     it['text']=response.json()['text'].strip()
                     ok_nums+=1
                     self.signal(text=f"{i+1}/{len(raws)}")
@@ -49,18 +47,23 @@ class GLMASRRecogn(BaseRecogn):
                         type='subtitle'
                     )
                     break
-                
+
                 try:
                     err_json=response.json()
                 except Exception:
                     raise SpeechToTextError(response.text)
-                else:
-                    logger.error(err_json)
-                    code=str(err_json['error']['code'])
-                    if code in ["1302","1303","1214"]:
-                        time.sleep(5)
+                logger.error(err_json)
+                _error=(err_json.get('error') if isinstance(err_json, dict) else None) or {}
+                code=str(_error.get('code', ''))
+                err=_error.get('message') or response.text
+                if code in ["1302","1303","1214"]:
+                    if rate_limited < max_rate_limited:
+                        rate_limited+=1
+                        time.sleep(5 * rate_limited)
                         continue
-                    raise SpeechToTextError(err_json['error']['message'])
+                    it['text']=''
+                    break
+                raise SpeechToTextError(err)
             if self.asr_wait>0:
                 time.sleep(self.asr_wait)
         if ok_nums<1:

--- a/videotrans/recognition/_google.py
+++ b/videotrans/recognition/_google.py
@@ -9,6 +9,7 @@ import speech_recognition as sr
 from pydub import AudioSegment
 from pydub.silence import detect_nonsilent
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type, before_log, after_log
+from videotrans.configure._retry import stop_after_retry_nums
 
 from videotrans.configure.config import tr, settings, logger
 from videotrans.configure.excepts import NO_RETRY_EXCEPT
@@ -21,7 +22,7 @@ from videotrans.util.help_misc import vail_file
 @dataclass
 class GoogleRecogn(BaseRecogn):
 
-    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
+    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=stop_after_retry_nums(), wait=wait_fixed(2), before=before_log(logger, logging.INFO),  after=after_log(logger, logging.INFO))
     def _exec(self) -> Union[List[SrtItem], None]:
         if self._exit():  return
 

--- a/videotrans/recognition/_qwen3asr.py
+++ b/videotrans/recognition/_qwen3asr.py
@@ -19,7 +19,9 @@ from videotrans.task.taskcfg import SrtItem
 class Qwen3ASRRecogn(BaseRecogn):
     def __post_init__(self):
         super().__post_init__()
-        spaceid=params.get('qwenmt_spaceid', '')
+        spaceid=params.get('qwenmt_spaceid', '').strip()
+        # 未填写业务空间ID时使用百炼默认地址，否则 api_url 为空字符串，请求地址无协议头导致报错
+        self.api_url = 'https://dashscope.aliyuncs.com/api/v1'
         if spaceid and  not spaceid.startswith('http'):
             self.api_url = f'https://{spaceid}.cn-beijing.maas.aliyuncs.com/api/v1'
         elif spaceid and spaceid.startswith('http'):

--- a/videotrans/recognition/_qwen3asr.py
+++ b/videotrans/recognition/_qwen3asr.py
@@ -123,8 +123,19 @@ class Qwen3ASRRecogn(BaseRecogn):
             }
 
 
-            response = requests.post(self.api_url, headers=headers, json=payload,verify=False,proxies={"https":"","http":""})
-            if response.status_code in [400,401,403,404,422]:
+            try:
+                # 带 API Key 访问公网，保持证书校验
+                response = requests.post(self.api_url, headers=headers, json=payload, timeout=(30, 300), proxies={"https":"","http":""})
+            except requests.exceptions.RequestException as e:
+                error=str(e)
+                continue
+            if response.status_code in [401,403,404]:
+                raise StopTask(response.text)
+            if response.status_code in [400,422]:
+                # 单个片段被内容审核拦截时跳过该片段，其他参数错误仍中止任务
+                if 'DataInspectionFailed' in response.text:
+                    error=response.text
+                    continue
                 raise StopTask(response.text)
             if response.status_code!=200:
                 error=response.text

--- a/videotrans/recognition/_recognapi.py
+++ b/videotrans/recognition/_recognapi.py
@@ -38,9 +38,9 @@ class APIRecogn(BaseRecogn):
 
     def __post_init__(self):
         super().__post_init__()
-        api_url = params.get('recognapi_url', '').strip().rstrip('/').lower()
+        api_url = params.get('recognapi_url', '').strip().rstrip('/')
 
-        if not api_url.startswith('http'):
+        if not api_url.lower().startswith('http'):
             api_url = f'http://{api_url}'
 
         if params.get('recognapi_key'):
@@ -80,10 +80,6 @@ class APIRecogn(BaseRecogn):
             }
             testdata=json.dumps(testdata,ensure_ascii=False)
             raise SpeechToTextError(f'识别出错,应返回类似数据:\n{testdata}\n\n但实际返回: {res}')
-        self.signal(
-            text=get_srt_from_list(res['data']),
-            type='replace_subtitle'
-        )
 
         if isinstance(res['data'],list):
             data=[f'{i+1}\n{it["time"]}\n{it["text"]}' for i,it in enumerate(res['data'])]
@@ -91,6 +87,8 @@ class APIRecogn(BaseRecogn):
         else:
             data=res['data']
         
+        # data 为 SRT 字符串（列表时已在上方转换），直接用于界面显示
+        self.signal(text=data, type='replace_subtitle')
         return get_subtitle_from_srt(data, is_file=False)
         
 
@@ -193,13 +191,14 @@ class APIRecogn(BaseRecogn):
                 try:
                     segments = ast.literal_eval(list_str)
                 except (ValueError, SyntaxError):
-                    context = {
-                        "null": None,
-                        "true": True,
-                        "false": False,
-                        "__builtins__": None
-                    }
-                    segments = eval(list_str, context)
+                    # 兼容 JSON 字面量 null/true/false，只做字面量解析，不执行服务器返回的内容
+                    try:
+                        _normalized = re.sub(r'\bnull\b', 'None', list_str)
+                        _normalized = re.sub(r'\btrue\b', 'True', _normalized)
+                        _normalized = re.sub(r'\bfalse\b', 'False', _normalized)
+                        segments = ast.literal_eval(_normalized)
+                    except (ValueError, SyntaxError) as e:
+                        logger.error(f"Parse vibevoice-asr result failed: {e}")
             except Exception as e:
                 logger.error(f"AST eval failed: {e}")
             if not segments:

--- a/videotrans/recognition/_stt.py
+++ b/videotrans/recognition/_stt.py
@@ -29,6 +29,7 @@ from videotrans.util._srt_parse import get_subtitle_from_srt
 """
 
 from tenacity import retry, stop_after_attempt, wait_fixed, retry_if_not_exception_type, before_log, after_log
+from videotrans.configure._retry import stop_after_retry_nums
 import logging
 
 
@@ -37,15 +38,15 @@ class SttAPIRecogn(BaseRecogn):
 
     def __post_init__(self):
         super().__post_init__()
-        api_url = params.get('stt_url', '').strip().rstrip('/').lower()
+        api_url = params.get('stt_url', '').strip().rstrip('/')
         if not api_url:
             raise SpeechToTextError(tr("Custom api address must be filled in"))
 
-        if not api_url.startswith('http'):
+        if not api_url.lower().startswith('http'):
             api_url = f'http://{api_url}'
         self.api_url = f'{api_url}/api' if not api_url.endswith('/api') else api_url
 
-    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=(stop_after_attempt(settings.get('retry_nums'))), wait=wait_fixed(2), before=before_log(logger, logging.INFO), after=after_log(logger, logging.INFO))
+    @retry(retry=retry_if_not_exception_type(NO_RETRY_EXCEPT), stop=stop_after_retry_nums(), wait=wait_fixed(2), before=before_log(logger, logging.INFO), after=after_log(logger, logging.INFO))
     def _exec(self) -> Union[List[SrtItem],None]:
         if self._exit(): return
         with open(self.audio_file, 'rb') as f:

--- a/videotrans/recognition/_whispernet.py
+++ b/videotrans/recognition/_whispernet.py
@@ -212,7 +212,8 @@ class WhisperNetRecogn(BaseRecogn):
                 builder = builder.WithLanguageDetection()
 
             # 设置其他参数
-            if settings.get('condition_on_previous_text', False):
+            # 未启用“以前文为条件”时才关闭上下文
+            if not settings.get('condition_on_previous_text', False):
                 builder = builder.WithNoContext()
             builder = builder.WithNoSpeechThreshold(float(settings.get('no_speech_threshold', -0.8)))
             builder = builder.WithLogProbThreshold(float(settings.get('logprob_threshold', -1.0)))

--- a/videotrans/recognition/_xxl.py
+++ b/videotrans/recognition/_xxl.py
@@ -53,13 +53,14 @@ class XXLRecogn(BaseRecogn):
         return ":".join(_hms)+f",{ms}"
         
     def _getsrt_from_stdout(self,content,srt_filename):
-        s=re.findall(r'\n(\[([\d:\.]+?) --> ([\d:\.]+?)\])\s(.+?)\n',content,flags=re.S)
+        # 按行匹配，避免前一行末尾换行被消耗后相邻字幕行漏匹配
+        s=re.findall(r'^\[([\d:\.]+?) --> ([\d:\.]+?)\][ \t]*(.+?)[ \t]*\r?$',content,flags=re.M)
 
         if not s or len(s)<1:
             return
         srts=[]
         for i,it in enumerate(s):
-            srts.append(f"{i+1}\n{self._return_time(it[1])} --> {self._return_time(it[2])}\n{it[3].strip()}")
+            srts.append(f"{i+1}\n{self._return_time(it[0])} --> {self._return_time(it[1])}\n{it[2].strip()}")
         if not srts:
             return
         

--- a/videotrans/task/update_ffmpeg.py
+++ b/videotrans/task/update_ffmpeg.py
@@ -10,67 +10,98 @@ For more information, visit the FFmpeg GitHub repository: https://github.com/Btb
 This script is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the authors be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the script or the use or other dealings in the script.
 """
 
+import glob
+import hashlib
 import os
+import re
 import shutil
+import sys
 import zipfile
 
 import requests
 
-# Gets the current script's directory
-script_dir = os.path.dirname(os.path.abspath(__file__))
+RELEASE_API = "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/tags/latest"
+CHECKSUM_FILE = "checksums.sha256"
+FALLBACK_ZIP = "ffmpeg-master-latest-win64-gpl.zip"
 
-# Defines the destination directory and temporary directory relative to the script directory
-dest_dir = os.path.join(script_dir, "..", "..", "ffmpeg")
-temp_dir = os.path.join(dest_dir, "temp_ffmpeg")
-os.makedirs(dest_dir, exist_ok=True)
 
-# GitHub API URL to get the latest ffmpeg version
-api_url = "https://api.github.com/repos/BtbN/FFmpeg-Builds/releases/latest"
-response = requests.get(api_url)
-latest_release = response.json()
-latest_version = latest_release["tag_name"]
-download_url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-n7.0-latest-win64-gpl-7.0.zip"
+def _stable_version(name):
+    # 形如 ffmpeg-n8.1-latest-win64-gpl-8.1.zip 的稳定版（非 shared）
+    m = re.match(r"ffmpeg-n(\d+)\.(\d+)-latest-win64-gpl-\1\.\2\.zip$", name)
+    return (int(m.group(1)), int(m.group(2))) if m else None
 
-# Destination path for the download
-zip_path = os.path.join(dest_dir, "ffmpeg.zip")
 
-# Download the zip file
-print("Downloading ffmpeg.zip...")
-with requests.get(download_url, stream=True) as r:
-    r.raise_for_status()
-    with open(zip_path, "wb") as f:
-        for chunk in r.iter_content(chunk_size=8192):
-            f.write(chunk)
+def _expected_sha256(checksums_text, zip_name):
+    for line in checksums_text.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[1].lstrip("*") == zip_name:
+            return parts[0].lower()
+    return None
 
-# Extract the contents of the zip file
-print("Extracting the contents of ffmpeg.zip...")
-with zipfile.ZipFile(zip_path, "r") as zip_ref:
-    zip_ref.extractall(temp_dir)
 
-# Paths to the binaries within the extracted zip file
-ffmpeg_exe = os.path.join(
-    temp_dir, "ffmpeg-n7.0-latest-win64-gpl-7.0", "bin", "ffmpeg.exe"
-)
-ffprobe_exe = os.path.join(
-    temp_dir, "ffmpeg-n7.0-latest-win64-gpl-7.0", "bin", "ffprobe.exe"
-)
+def main():
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    dest_dir = os.path.join(script_dir, "..", "..", "ffmpeg")
+    temp_dir = os.path.join(dest_dir, "temp_ffmpeg")
+    os.makedirs(dest_dir, exist_ok=True)
 
-# Checks if the files already exist and removes them if necessary
-if os.path.exists(os.path.join(dest_dir, "ffmpeg.exe")):
-    print("Removing existing ffmpeg.exe file...")
-    os.remove(os.path.join(dest_dir, "ffmpeg.exe"))
-if os.path.exists(os.path.join(dest_dir, "ffprobe.exe")):
-    print("Removing existing ffprobe.exe file...")
-    os.remove(os.path.join(dest_dir, "ffprobe.exe"))
+    response = requests.get(RELEASE_API, timeout=30)
+    response.raise_for_status()
+    assets = {a["name"]: a["browser_download_url"] for a in response.json().get("assets", [])}
 
-# Moves the new binaries to the destination directory
-print("Moving new binaries to the destination directory...")
-shutil.move(ffmpeg_exe, os.path.join(dest_dir, "ffmpeg.exe"))
-shutil.move(ffprobe_exe, os.path.join(dest_dir, "ffprobe.exe"))
+    stable = sorted((n for n in assets if _stable_version(n)), key=_stable_version)
+    zip_name = stable[-1] if stable else FALLBACK_ZIP
+    if zip_name not in assets or CHECKSUM_FILE not in assets:
+        sys.exit(f"Release assets not found: {zip_name} / {CHECKSUM_FILE}")
 
-# Clean up temporary files
-print("Cleaning up temporary files...")
-os.remove(zip_path)
-shutil.rmtree(temp_dir)
+    checksums = requests.get(assets[CHECKSUM_FILE], timeout=30)
+    checksums.raise_for_status()
+    expected = _expected_sha256(checksums.text, zip_name)
+    if not expected:
+        sys.exit(f"No sha256 checksum found for {zip_name}")
 
-print("Download, extraction, and replacement completed!")
+    zip_path = os.path.join(dest_dir, "ffmpeg.zip")
+    print(f"Downloading {zip_name}...")
+    sha256 = hashlib.sha256()
+    with requests.get(assets[zip_name], stream=True, timeout=(15, 60)) as r:
+        r.raise_for_status()
+        with open(zip_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                f.write(chunk)
+                sha256.update(chunk)
+
+    # 校验下载文件的 sha256，不一致则删除并退出，避免替换为被篡改的可执行文件
+    if sha256.hexdigest().lower() != expected:
+        os.remove(zip_path)
+        sys.exit(f"sha256 mismatch for {zip_name}, download discarded")
+    print("sha256 verified")
+
+    print("Extracting the contents of ffmpeg.zip...")
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        zip_ref.extractall(temp_dir)
+
+    bin_dirs = glob.glob(os.path.join(temp_dir, "*", "bin"))
+    if not bin_dirs:
+        sys.exit("bin directory not found in the downloaded archive")
+    ffmpeg_exe = os.path.join(bin_dirs[0], "ffmpeg.exe")
+    ffprobe_exe = os.path.join(bin_dirs[0], "ffprobe.exe")
+
+    for exe in ("ffmpeg.exe", "ffprobe.exe"):
+        target = os.path.join(dest_dir, exe)
+        if os.path.exists(target):
+            print(f"Removing existing {exe} file...")
+            os.remove(target)
+
+    print("Moving new binaries to the destination directory...")
+    shutil.move(ffmpeg_exe, os.path.join(dest_dir, "ffmpeg.exe"))
+    shutil.move(ffprobe_exe, os.path.join(dest_dir, "ffprobe.exe"))
+
+    print("Cleaning up temporary files...")
+    os.remove(zip_path)
+    shutil.rmtree(temp_dir)
+
+    print("Download, verification, extraction, and replacement completed!")
+
+
+if __name__ == "__main__":
+    main()

--- a/videotrans/translator/_qwenmt.py
+++ b/videotrans/translator/_qwenmt.py
@@ -17,10 +17,11 @@ class QwenMT(BaseTrans):
 
     def __post_init__(self):
         super().__post_init__()
-        spaceid=params.get('qwenmt_spaceid', '')
+        spaceid=params.get('qwenmt_spaceid', '').strip()
 
         self.prompt=self._set_context()
-        
+        # 未填写业务空间ID时使用百炼默认地址，避免将 dashscope.base_http_api_url 置为空字符串
+        self.api_url = 'https://dashscope.aliyuncs.com/api/v1'
         if spaceid and  not spaceid.startswith('http'):
             self.api_url = f'https://{spaceid}.cn-beijing.maas.aliyuncs.com/api/v1'
         elif spaceid and spaceid.startswith('http'):

--- a/videotrans/tts/_ai302tts.py
+++ b/videotrans/tts/_ai302tts.py
@@ -61,7 +61,7 @@ class AI302(BaseTTS):
         response = requests.post('https://api.302.ai/302/v2/audio/tts', headers={
             'Authorization': f'Bearer {params.get("ai302_key","")}',
             'Content-Type': 'application/json'
-        }, data=json.dumps(payload), verify=False)
+        }, data=json.dumps(payload))
         if response.status_code in [401,403,402,404]:
             raise StopTask(response.text)
         response.raise_for_status()

--- a/videotrans/tts/_glmtts.py
+++ b/videotrans/tts/_glmtts.py
@@ -39,7 +39,7 @@ class GLMTTS(BaseTTS):
         response = requests.post(url, headers={
             'Authorization': f'Bearer {params.get("zhipu_key","")}',
             'Content-Type': 'application/json'
-        }, data=json.dumps(payload), verify=False)
+        }, data=json.dumps(payload))
         if response.status_code in [401,403,404,434]:
             raise StopTask(response.text)
         content_type = response.headers.get('Content-Type')

--- a/videotrans/tts/_qwentts.py
+++ b/videotrans/tts/_qwentts.py
@@ -40,7 +40,7 @@ class QWENTTS(BaseTTS):
         if vail_file(data_item['filename']):return
         role = self.role_dict.get(data_item['role'],'Cherry')
         try:
-            logger.debug(f"[Qwen-TTS(bailian)]{self.model=},{self.api_key=},{role=},{data_item['text']=},{self.target_language=}")
+            logger.debug(f"[Qwen-TTS(bailian)]{self.model=},{role=},{data_item['text']=},{self.target_language=}")
             response = dashscope.MultiModalConversation.call(
                 model=self.model,
                 # 新加坡和北京地域的API Key不同。获取API Key：https://help.aliyun.com/zh/model-studio/get-api-key

--- a/videotrans/tts/_xaitts.py
+++ b/videotrans/tts/_xaitts.py
@@ -39,7 +39,7 @@ class XAITTS(BaseTTS):
             response = requests.post('https://api.x.ai/v1/tts', headers={
             'Authorization': f'Bearer {params.get("xaitts_key","")}',
             'Content-Type': 'application/json'
-            }, json=payload, verify=False)
+            }, json=payload)
         
             if response.status_code in [401,403,404,405,415,422]:
                 raise StopTask(response.text)

--- a/videotrans/util/help_misc.py
+++ b/videotrans/util/help_misc.py
@@ -40,6 +40,9 @@ def show_popup(title, text):
 
 def show_error(tb_str):
     """槽函数 显示对话框。"""
+    from videotrans.configure._redact import redact
+    # 脱敏后再显示和用于报告错误，避免 API Key 出现在弹窗和论坛链接中
+    tb_str = redact(str(tb_str))
     from PySide6 import QtWidgets
     from PySide6.QtGui import QIcon, QDesktopServices
     from PySide6.QtCore import QUrl, Qt

--- a/videotrans/winform/chatgpt.py
+++ b/videotrans/winform/chatgpt.py
@@ -23,7 +23,6 @@ def openwin():
         params["chatgpt_model"] = winobj.chatgpt_model.currentText()
         params["chatgpt_reasoning_effort"] = winobj.reasoning_effort.currentText()
         params.save()
-        os.environ['OPENAI_API_KEY'] = key
         winobj.test_chatgpt.setText(tr("Testing..."))
         from videotrans import translator
         task = TestSrtTrans(parent=winobj, translator_type=translator.CHATGPT_INDEX)

--- a/videotrans/winform/gemini.py
+++ b/videotrans/winform/gemini.py
@@ -14,7 +14,6 @@ def openwin():
 
     def test():
         key = winobj.gemini_key.text().strip()
-        os.environ['GOOGLE_API_KEY'] = key
         params["gemini_key"] = key
         params["gemini_model"] = winobj.model.currentText()
         params["gemini_maxtoken"] = winobj.gemini_maxtoken.text()

--- a/webui.py
+++ b/webui.py
@@ -205,6 +205,14 @@ def _format_pitch(v):
     return f"+{v}Hz" if v >= 0 else f"{v}Hz"
 
 
+def _is_secret_field(key: str) -> bool:
+    """API Key、密钥、Token 等字段以密码框显示，避免被旁人看到"""
+    k = key.lower()
+    if 'max_token' in k or 'maxtoken' in k:
+        return False
+    return k.endswith(('key', 'secret', 'secretid', 'token'))
+
+
 def _safe_get(key, default=""):
     """从 _user_params 读取值，支持 str/int/float/bool"""
     v = _user_params.get(key, default)
@@ -592,6 +600,7 @@ def build_channel_settings():
                                 label=f["label"],
                                 value=val,
                                 placeholder=f.get("placeholder", ""),
+                                type="password" if _is_secret_field(f["key"]) else "text",
                                 interactive=True,
                             )
                             fields.append((f["key"], tb))
@@ -1226,12 +1235,21 @@ if __name__ == "__main__":
         import argparse
         import gradio as gr
         parser = argparse.ArgumentParser(description="pyVideoTrans WebUI")
-        parser.add_argument("--host", type=str, default="0.0.0.0", help="Host address")
+        parser.add_argument("--host", type=str, default="127.0.0.1", help="Host address, use 0.0.0.0 to allow LAN access")
         parser.add_argument("--port", type=int, default=7860, help="Port number")
         parser.add_argument("--share", action="store_true", help="Create a public Gradio link")
+        parser.add_argument("--auth", type=str, default="", help="Login credentials, format user:password")
         args = parser.parse_args()
+        auth = None
+        if args.auth:
+            if ':' not in args.auth:
+                parser.error("--auth must be in user:password format")
+            auth = tuple(args.auth.split(':', 1))
+        elif args.share or args.host not in ('127.0.0.1', 'localhost', '::1'):
+            # 设置页可查看和修改所有 API Key，对外开放时应启用登录验证
+            print("Warning: WebUI is reachable from other machines without --auth, anyone who can open the page can view the API keys in settings.")
         app = build_ui()
-        app.launch(server_name=args.host, server_port=args.port, share=args.share, inbrowser=True, theme=gr.themes.Soft(),css="""
+        app.launch(server_name=args.host, server_port=args.port, share=args.share, auth=auth, inbrowser=True, theme=gr.themes.Soft(),css="""
         /* 默认字体：微软雅黑 > 苹果方黑 > 系统无衬线字体 */
         *, *::before, *::after {
             font-family: "Microsoft YaHei", "PingFang SC", "Hiragino Sans GB", "WenQuanYi Micro Hei", "Noto Sans CJK SC", "Source Han Sans SC", "SimHei", sans-serif !important;


### PR DESCRIPTION
## 概述

本 PR 包含 4 个提交：

1. `aa424589` 修复阿里百炼 Qwen ASR / Qwen-MT 在未填写业务空间 ID 时报错
2. `f5913fd7` 安全加固：防止 API Key 泄露，加固依赖和下载来源
3. `173078bd` 修复多个识别渠道的音频转字幕 bug
4. `d585ba78` 回归测试

## 1. Qwen ASR / MT 未填写业务空间 ID 时报错

自 d21379f2 起，`dashscope.base_http_api_url = self.api_url` 改为无条件赋值，而 `api_url` 在 `BaseRecogn` / `BaseTrans` 中默认为空字符串。未填写业务空间 ID 时，请求地址缺少协议头，requests 抛出 `MissingSchema`；该全局设置被清空后，同一进程内的 Qwen TTS 也会失败。

现在先默认使用 `https://dashscope.aliyuncs.com/api/v1`，填写业务空间 ID 时按原逻辑覆盖。

## 2. 安全加固

- **密钥脱敏**：日志处理器、错误弹窗和“报告错误”链接中，对已配置的 Key、URL 中的 `key`/`sk`/`secret` 参数、`Bearer` 令牌以及 `sk-`/`AIza`/`hf_` 格式的密钥进行脱敏（新增 `videotrans/configure/_redact.py`）。此前报告错误时，错误全文会放进 `bbs.pyvideotrans.com` 链接的查询参数，打开页面时即发送到服务器。
- Qwen TTS 调试日志不再输出 `api_key`。
- 带 Key 访问公网的请求（302.AI、智谱、x.ai 配音，Qwen flash 识别）恢复证书校验。
- 测试 ChatGPT / Gemini 渠道后，不再把 Key 写入 `OPENAI_API_KEY` / `GOOGLE_API_KEY` 环境变量。
- 自定义识别 API（vibevoice-asr）解析服务器返回内容时不再使用 `eval()`（`__builtins__: None` 可被绕过），改为只解析字面量。
- **WebUI**：默认监听 `127.0.0.1`；新增 `--auth user:password`；Key 类字段改为密码框；允许其他机器访问且未设置 `--auth` 时打印警告。Dockerfile 显式传入 `--host 0.0.0.0`，`docs/webui.md` 已同步。
- **依赖**：`chatterbox-tts` 固定到提交 `5de7a54`（与原先锁定的 master 压缩包内容一致）；移除 `index-strategy = "unsafe-best-match"`（两个额外索引都是 explicit，移除后 `uv lock` 结果不变）。
- **update_ffmpeg.py**：原先写死的 `ffmpeg-n7.0-latest-win64-gpl-7.0.zip` 已从 release 中下架，脚本无法使用。现在通过 release API 选择最新稳定版，并用 `checksums.sha256` 校验下载文件。

## 3. 音频转字幕 bug

- **自定义识别 API**：按文档返回 SRT 字符串时，原代码把字符串当列表逐字符处理，必然报错；URL 不再整体转为小写（路径区分大小写的接口会 404）。
- **Faster-Whisper-XXL**：正则会吞掉行尾换行，导致相邻字幕行约一半被丢弃，改为按行匹配。
- **302.AI**：gpt-4o 模型读取了不存在的 `it['file']`（应为 `filename`），全部失败；说话人编号改为按首次出现顺序，保持一致。
- **Gemini**：汇总条目的起止时间改为加上片段偏移后的绝对时间，并带上完整文本；502/503 等错误继续抛出交给重试，不再返回 `None` 后崩溃。
- **BaseRecogn**：复制标点列表，避免中日韩任务向全局 `PUNC_FLAGS` 追加空格，影响后续英文任务的断句；`asr_wait` 改为实例化时读取设置。
- **Qwen flash 模型**：请求增加超时；单个片段被内容审核拦截（`DataInspectionFailed`）时跳过该片段，不再中止整个任务。
- **GLM-ASR**：限流（1302/1303/1214）时真正重试，全部失败时给出有效错误信息。
- **Whisper.NET**：`condition_on_previous_text` 的判断条件写反了。
- 识别渠道的重试次数改为每次重试时读取设置（新增 `videotrans/configure/_retry.py`）；修正 `logger.waring` 拼写并跳过模型列表文件中的空行；缺少 Key 时提示实际渠道名，而不是固定提示 Deepgram。

## 行为变化

- WebUI 默认不再允许局域网访问，需要显式传入 `--host 0.0.0.0`（建议同时使用 `--auth`）；Docker 镜像的默认行为不变。
- DeepLX 仍通过 URL 传递 key（兼容各类第三方部署），但日志和错误信息中已脱敏。
- 自定义 / 本地部署接口上的 `verify=False` 保持不变（这些服务可能使用自签名证书）。

## 测试

- 新增 `tests/test_security_stt_fixes.py`，16 个用例全部通过。
- 全量测试：403 passed、54 failed、1 error。这 54 个失败和 1 个错误在本 PR 之前的 `main` 上已经存在（例如 `test_job_helpers` 导入 `_get_type_name` 失败、翻译渠道索引常量的断言过期），本 PR 没有引入新的失败。
- 离线验证了未填写业务空间 ID 时，dashscope 实际请求地址为 `https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation`。
- 未使用真实 API Key 逐一调用各渠道，也未实际执行 ffmpeg 下载。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6JuFozRpMtuazDKryBj65
